### PR TITLE
fix a bug with heatmap's colormap when values contained NaN

### DIFF
--- a/bgheatmaps/heatmaps.py
+++ b/bgheatmaps/heatmaps.py
@@ -40,7 +40,10 @@ def check_values(values: dict, atlas: Atlas) -> Tuple[float, float]:
         if k not in atlas.lookup_df.acronym.values:
             raise ValueError(f'Region name "{k}" not recognized')
 
-    vmax, vmin = max(values.values()), min(values.values())
+    not_nan = [v for v in values.values() if not np.isnan(v)]
+    if len(not_nan) == 0:
+        return np.nan, np.nan
+    vmax, vmin = max(not_nan), min(not_nan)
     return vmax, vmin
 
 
@@ -108,8 +111,8 @@ class heatmap:
         if _vmax == _vmin:
             _vmin = _vmax * 0.5
 
-        vmin = vmin or _vmin
-        vmax = vmax or _vmax
+        vmin = vmin if vmin == 0 or vmin else _vmin
+        vmax = vmax if vmax == 0 or vmax else _vmax
         self.vmin, self.vmax = vmin, vmax
 
         self.colors = {


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

## Description

**What is this PR**

Bug fix

I know this project is momentarily unmaintained. For this reason i don't expect this PR to be merged any time soon.
In the meantime, I prefer submitting it.

**Why is this PR needed?**

with the following values, the color mapping is wrong:
```python
import vedo as vd
import bgheatmaps as bgh
import numpy as np

vd.embedWindow("k3d")

values = {'MO': np.nan, 'RHP': 5, 'AUD': -5}    # does NOT work -> uses cmin=np.nan
# values = {'RHP': 5, 'MO': np.nan, 'AUD': -5}  # does NOT work -> uses cmin=-5
# values = {'RHP': 5, 'AUD': -5, 'MO': np.nan}  # does NOT work -> uses cmin=-5


h = bgh.heatmap(
    values,
    position=5000,  # when using a named orientation you can pass a single value!
    orientation="frontal",  # 'frontal' or 'sagittal', or 'horizontal' or a tuple (x,y,z)
    title="horizontal view",
    vmin=0,
    vmax=3,
    format="2D",
)
h.show()
```

**What does this PR do?**
checks for `nan` values and allows users to set `cmin=0` or `cmax=0`

## How has this PR been tested?

with the above mentioned code

## Is this a breaking change?

no

## Does this PR require an update to the documentation?

no
