### PR TITLE
small fixes following #21

### DIFF
--- a/brainglobe_heatmap/heatmaps.py
+++ b/brainglobe_heatmap/heatmaps.py
@@ -19,10 +19,10 @@ settings.ROOT_COLOR = grey_darker
 
 # Set settings for transparent background
 # vedo for transparent bg
-# settings.vsettings.screenshotTransparentBackground = True
+# settings.vsettings.screenshot_transparent_background = True
 
 # This needs to be false for transparent bg
-# settings.vsettings.useFXAA = False
+# settings.vsettings.use_fxaa = False
 
 
 def check_values(values: dict, atlas: Atlas) -> Tuple[float, float]:
@@ -157,7 +157,7 @@ class heatmap:
                 camera = self.orientation
         else:
             self.orientation = np.array(self.orientation)
-            com = self.slicer.plane0.centerOfMass()
+            com = self.slicer.plane0.center_of_mass()
             camera = {
                 "pos": com - self.orientation * 2 * np.linalg.norm(com),
                 "viewup": (0, -1, 0),

--- a/brainglobe_heatmap/plane.py
+++ b/brainglobe_heatmap/plane.py
@@ -5,7 +5,10 @@ import vedo as vd
 import vtkmodules.all as vtk
 from brainrender.actor import Actor
 
-vtk.vtkLogger.SetStderrVerbosity(vtk.vtkLogger.VERBOSITY_OFF) # remove logger's prints during intersect_with_plane()
+vtk.vtkLogger.SetStderrVerbosity(
+    vtk.vtkLogger.VERBOSITY_OFF
+)  # remove logger's prints during intersect_with_plane()
+
 
 class Plane:
     def __init__(

--- a/brainglobe_heatmap/plane.py
+++ b/brainglobe_heatmap/plane.py
@@ -50,16 +50,16 @@ class Plane:
         plane_mesh.width = length
         return plane_mesh
 
-    def centerOfMass(self):
+    def center_of_mass(self):
         return self.center
 
-    def P3toP2(self, ps):
+    def p3_to_p2(self, ps):
         # ps is a list of 3D points
         # returns a list of 2D point mapped on
         # the plane (u -> x axis, v -> y axis)
         return (ps - self.center) @ self.M
 
-    def intersectWith(self, mesh: vd.Mesh):
+    def intersect_with(self, mesh: vd.Mesh):
         return mesh.intersect_with_plane(
             origin=self.center, normal=self.normal
         )
@@ -69,14 +69,14 @@ class Plane:
         projected = {}
         for actor in actors:
             mesh: vd.Mesh = actor._mesh
-            intersection = self.intersectWith(mesh)
+            intersection = self.intersect_with(mesh)
             if not intersection.vertices.shape[0]:
                 continue
             pieces = intersection.split()  # intersection.split() in newer vedo
             for piece_n, piece in enumerate(pieces):
                 # sort coordinates
                 points = piece.join(reset=True).vertices
-                projected[actor.name + f"_segment_{piece_n}"] = self.P3toP2(
+                projected[actor.name + f"_segment_{piece_n}"] = self.p3_to_p2(
                     points
                 )
         return projected

--- a/brainglobe_heatmap/slicer.py
+++ b/brainglobe_heatmap/slicer.py
@@ -6,6 +6,7 @@ from brainrender.scene import Scene
 
 from brainglobe_heatmap.plane import Plane
 
+
 def get_ax_idx(orientation: str) -> int:
     """
     Given a named orientation get the idx

--- a/brainglobe_heatmap/slicer.py
+++ b/brainglobe_heatmap/slicer.py
@@ -35,7 +35,7 @@ class Slicer:
         3D vector) + thickness (spacing between the two planes)
         """
         if position is None:
-            position = root.centerOfMass()
+            position = root.center_of_mass()
 
         if isinstance(position, (float, int)):
             if isinstance(orientation, str):
@@ -122,7 +122,7 @@ class Slicer:
         to the brainrender scene.
         """
         for region in regions + [root]:
-            intersection = self.plane0.intersectWith(region._mesh)
+            intersection = self.plane0.intersect_with(region._mesh)
 
             if len(intersection.vertices):
                 scene.add(intersection, transform=False)

--- a/brainglobe_heatmap/slicer.py
+++ b/brainglobe_heatmap/slicer.py
@@ -6,7 +6,6 @@ from brainrender.scene import Scene
 
 from brainglobe_heatmap.plane import Plane
 
-
 def get_ax_idx(orientation: str) -> int:
     """
     Given a named orientation get the idx


### PR DESCRIPTION
This PR:
* uses `intersect_with_plane()` from newest `vedo` instead of the backported function as there is no longer the need to duplicate code from an updated dependency thanks to #21 
* fixes some `vedo` function calls still using `lowerCamelCase` instead of `snake_case`

Additionally I changed `Plane.from_norm()` typing to return a `Self` type instead of a `vd.Plane` because, well, that's what it returns. If this is a problem because `typing.Self` is not in previous python version, I can just remove the type hinting