### PR TITLE
add 'hemisphere' option to heatmap()

### DIFF
--- a/brainglobe_heatmap/heatmaps.py
+++ b/brainglobe_heatmap/heatmaps.py
@@ -54,6 +54,7 @@ class heatmap:
         values: Dict[str, float],
         position: Union[list, tuple, np.ndarray],
         orientation: Union[str, tuple] = "frontal",
+        hemisphere: str = "both",
         title: Optional[str] = None,
         cmap: str = "Reds",
         vmin: Optional[float] = None,
@@ -89,7 +90,7 @@ class heatmap:
         self.prepare_colors(values, cmap, vmin, vmax)
 
         # add regions to the brainrender scene
-        self.scene.add_brain_region(*self.values.keys())
+        self.scene.add_brain_region(*self.values.keys(), hemisphere=hemisphere)
 
         self.regions_meshes = [
             r


### PR DESCRIPTION
## Description

This small PR adds the `hemisphere` option in order to plot only the `right`, `left` or `both` hemispheres.
This can be useful when comparing two different but symmetrical data.

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other
