### PR TITLE
Update examples to new atlasapi name and version

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ coordinates = bgh.get_plane_coordinates(
 ## Using `brainglobe-heatmap` with other atlases.
 
 `brainglobe-heatmap` uses `brainrender` which, in turn, uses brainglobe's `Atlas API` under the hood. That means that all of `brainglobe-heatmap`'s functionality is compatible with any of the atlases supported by the atlas API. `bgh.heatmap`, `bgh.planner` and `bgh.get_plane_coordinates` all accept a `atlas_name` argument, pass the name of the atlas name you'd like to use!
-For more information see the API's [documentation](https://brainglobe.info/documentation/bg-atlasapi/index.html).
+For more information see the API's [documentation](https://brainglobe.info/documentation/brainglobe-atlasapi/index.html).
 
 ## Contributing
 Contributions to `brainglobe-heatmap` are more than welcome. Please see the [Developer's guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

--- a/examples/cellfinder_cell_density.py
+++ b/examples/cellfinder_cell_density.py
@@ -5,7 +5,7 @@
 """
 
 import pandas as pd
-from bg_atlasapi.bg_atlas import BrainGlobeAtlas
+from brainglobe_atlasapi.bg_atlas import BrainGlobeAtlas
 from brainrender._io import load_mesh_from_file
 
 import brainglobe_heatmap as bgh

--- a/examples/slicer_2D.py
+++ b/examples/slicer_2D.py
@@ -5,7 +5,7 @@
 """
 
 import matplotlib.patheffects as path_effects
-from bg_atlasapi import BrainGlobeAtlas
+from brainglobe_atlasapi import BrainGlobeAtlas
 from matplotlib import pyplot as plt
 
 import brainglobe_heatmap as bgh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "brainglobe-heatmap"
-authors = [{name = "Federico Claudi", email= "hello@brainglobe.info"}]
+authors = [{ name = "Federico Claudi", email = "hello@brainglobe.info" }]
 description = "Rendering anatomical heatmaps with brainrender and matplotlib"
 readme = "README.md"
 requires-python = ">=3.9.0"
@@ -8,7 +8,7 @@ dynamic = ["version"]
 
 dependencies = ["brainrender", "matplotlib", "numpy", "myterial", "rich"]
 
-license = {text = "MIT"}
+license = { text = "MIT" }
 
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",
@@ -30,24 +30,20 @@ classifiers = [
 
 [project.optional-dependencies]
 dev = [
-  "pytest",
-  "pytest-cov",
-  "coverage",
-  "tox",
-  "black",
-  "mypy",
-  "pre-commit",
-  "ruff",
-  "setuptools_scm",
+    "pytest",
+    "pytest-cov",
+    "coverage",
+    "tox",
+    "black",
+    "mypy",
+    "pre-commit",
+    "ruff",
+    "setuptools_scm",
 ]
 
 
 [build-system]
-requires = [
-    "setuptools>=45",
-    "wheel",
-    "setuptools_scm[toml]>=6.2",
-]
+requires = ["setuptools>=45", "wheel", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
@@ -69,18 +65,20 @@ line-length = 79
 
 [tool.check-manifest]
 ignore = [
-  ".yaml",
-  "tox.ini",
-  "tests/",
-  "tests/test_unit/",
-  "tests/test_integration/",
+    ".yaml",
+    "tox.ini",
+    "tests/",
+    "tests/test_unit/",
+    "tests/test_integration/",
 ]
 
 [tool.ruff]
 line-length = 79
-exclude = ["__init__.py","build",".eggs"]
-select = ["I", "E", "F"]
+exclude = ["__init__.py", "build", ".eggs"]
 fix = true
+
+[tool.ruff.lint]
+select = ["I", "E", "F"]
 
 [tool.tox]
 legacy_tox_ini = """


### PR DESCRIPTION
As per https://github.com/brainglobe/BrainGlobe/issues/43 |

This package itself doesn't depend on `brainglobe-atlasapi` directly, but the example scripts and some of the links in the README do. No need for a new version release after merging.