### PR TITLE
settings.ROOT_COLOR changes 2D plots in addition to 3D brainrender plots

### DIFF
--- a/brainglobe_heatmap/heatmaps.py
+++ b/brainglobe_heatmap/heatmaps.py
@@ -121,7 +121,7 @@ class heatmap:
             r: list(map_color(v, name=cmap, vmin=vmin, vmax=vmax))
             for r, v in values.items()
         }
-        self.colors["root"] = grey_darker
+        self.colors["root"] = settings.ROOT_COLOR
 
     def show(self, **kwargs) -> Union[Scene, plt.Figure]:
         """


### PR DESCRIPTION
## Description

**What is this PR**

Usability improvement

**Why is this PR needed?**

I found myself wanting to change the root colour for the 2D matplotlib plots. This was especially useful when using a Greys (B-W) colourmap, as the grey background can make some regions invisible. 

**What does this PR do?**

Currently the root region setting appears to only control the root region colour in the 3D brainrender plots. To me it would be intuitive to have the 2D matplotlib plots also read this value so that it only need be set once at the top of the file.

## How has this PR been tested?

Externally, I am now able to do something like `bgh.heatmaps.settings.ROOT_COLOR = white` and have this produce the 2D brain image with a white background.

## Does this PR require an update to the documentation?

Unsure.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
