### PR TITLE
run CI on both types of Mac

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -31,7 +31,9 @@ jobs:
         os: [ubuntu-latest]
         # Include one windows and macos run
         include:
-        - os: macos-latest
+        - os: macos-13 # Intel Mac
+          python-version: "3.10"
+        - os: macos-latest # ARM Mac
           python-version: "3.10"
         - os: windows-latest
           python-version: "3.10"


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

We'd like to run CI on both Intel and Silicon Macs.

**What does this PR do?**

This PR modifies the workflow file so that test and installation runs smoothly on both Mac architectures.

## References
Partial solution to https://github.com/brainglobe/BrainGlobe/issues/63

## How has this PR been tested?

CI runs observed.

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

No

## Checklist:

- [n/a] The code has been tested locally
- [n/a] Tests have been added to cover all new functionality (unit & integration)
- [n/a] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
