### PR TITLE
Add atlas caching

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -39,7 +39,7 @@ jobs:
           python-version: "3.10"
 
     steps:
-      - name: Cache atlases
+      - name: Cache brainglobe directory
         uses: actions/cache@v3
         with:
           path: | # ensure we don't cache any interrupted atlas download and extraction, if e.g. we cancel the workflow manually

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -39,6 +39,13 @@ jobs:
           python-version: "3.10"
 
     steps:
+      - name: Cache atlases
+        uses: actions/cache@v3
+        with:
+          path: | # ensure we don't cache any interrupted atlas download and extraction, if e.g. we cancel the workflow manually
+            ~/.brainglobe
+            !~/.brainglobe/atlas.tar.gz
+          key: brainglobe
       - name: install HDF libs on ARM Mac
         if: matrix.os == 'macos-latest'
         run: brew install hdf5


### PR DESCRIPTION
The atlases aren't currently needed for the tests (there aren't any), but this will speed them up when tests are added.
