### PR TITLE
Small formatting fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The position of the center of the plane is given by a set of `(x, y, z)` coordin
 Whe using one of the named orientation, you don't need to pass a whole set of `(x, y, z)` coordinates for the plane center. A single value is sufficient as the other two won't affect the plane position:
 
 ```python
-f = bgh.heatmap(
+f = bgh.Heatmap(
     values,
     position=1000,
     orientation="sagittal",  # 'frontal' or 'sagittal', or 'horizontal' or a tuple (x,y,z)
@@ -84,7 +84,7 @@ f = bgh.heatmap(
 
 Also, you can create a slice with a plane centered in the brain by passing `position=None`:
 ```python
-f = bgh.heatmap(
+f = bgh.Heatmap(
     values,
     position=None,
     orientation="sagittal",  # 'frontal' or 'sagittal', or 'horizontal' or a tuple (x,y,z)
@@ -100,7 +100,7 @@ Once happy with the position of the slicing planes, creating a visualization is 
 
 ```python
 
-bgh.heatmap(
+bgh.Heatmap(
     values,
     position=(
         8000,

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ Whe using one of the named orientation, you don't need to pass a whole set of `(
 f = bgh.Heatmap(
     values,
     position=1000,
-    orientation="sagittal",  # 'frontal' or 'sagittal', or 'horizontal' or a tuple (x,y,z)
+    orientation="sagittal",
+    # 'frontal' or 'sagittal', or 'horizontal' or a tuple (x,y,z)
     thickness=1000,
     atlas_name="allen_cord_20um",
     format='2D',
@@ -83,11 +84,13 @@ f = bgh.Heatmap(
 ```
 
 Also, you can create a slice with a plane centered in the brain by passing `position=None`:
+
 ```python
 f = bgh.Heatmap(
     values,
     position=None,
-    orientation="sagittal",  # 'frontal' or 'sagittal', or 'horizontal' or a tuple (x,y,z)
+    orientation="sagittal",
+    # 'frontal' or 'sagittal', or 'horizontal' or a tuple (x,y,z)
     thickness=1000,
     atlas_name="mpin_zfish_1um",
     format='2D',
@@ -107,7 +110,8 @@ bgh.Heatmap(
         5000,
         5000,
     ),
-    orientation="horizontal",  # 'frontal' or 'sagittal', or 'horizontal' or a tuple (x,y,z)
+    orientation="horizontal",
+    # 'frontal' or 'sagittal', or 'horizontal' or a tuple (x,y,z)
     title="horizontal view",
     vmin=-5,
     vmax=3,

--- a/brainglobe_heatmap/__init__.py
+++ b/brainglobe_heatmap/__init__.py
@@ -6,6 +6,6 @@ except PackageNotFoundError:
     # package is not installed
     pass
 
-from brainglobe_heatmap.heatmaps import heatmap
+from brainglobe_heatmap.heatmaps import Heatmap
 from brainglobe_heatmap.planner import plan
 from brainglobe_heatmap.slicer import get_structures_slice_coords

--- a/brainglobe_heatmap/heatmaps.py
+++ b/brainglobe_heatmap/heatmaps.py
@@ -48,7 +48,7 @@ def check_values(values: dict, atlas: Atlas) -> Tuple[float, float]:
     return vmax, vmin
 
 
-class heatmap:
+class Heatmap:
     def __init__(
         self,
         values: Dict,

--- a/brainglobe_heatmap/planner.py
+++ b/brainglobe_heatmap/planner.py
@@ -16,7 +16,7 @@ from rich.panel import Panel
 from rich.table import Table
 from vedo import Arrow, Sphere
 
-from brainglobe_heatmap.heatmaps import heatmap
+from brainglobe_heatmap.heatmaps import Heatmap
 from brainglobe_heatmap.plane import Plane
 
 settings.BACKGROUND_COLOR = amber_lighter
@@ -47,7 +47,7 @@ def print_plane(name: str, plane: Plane, color: str):
     )
 
 
-class plan(heatmap):
+class plan(Heatmap):
     def __init__(
         self,
         regions: Union[dict, list],

--- a/brainglobe_heatmap/planner.py
+++ b/brainglobe_heatmap/planner.py
@@ -116,38 +116,3 @@ class plan(Heatmap):
 
         self.scene.render(interactive=self.interactive, zoom=self.zoom)
         return self.scene
-
-
-if __name__ == "__main__":
-    regions = dict(  # scalar values for each region
-        TH=1,
-        RSP=0.2,
-        AI=0.4,
-        SS=-3,
-        MO=2.6,
-        PVZ=-4,
-        LZ=-3,
-        VIS=2,
-        AUD=0.3,
-        RHP=-0.2,
-        STR=0.5,
-        CB=0.5,
-        FRP=-1.7,
-        HIP=3,
-        PA=-4,
-    )
-
-    plan(
-        regions,
-        # position of the center point of the plane
-        position=(
-            8000,
-            5000,
-            5000,
-        ),
-        # or 'sagittal', or 'horizontal' or a tuple (x,y,z)
-        orientation="frontal",
-        # thickness of the slices used for rendering (in microns)
-        thickness=2000,
-        arrow_scale=750,
-    ).show()

--- a/brainglobe_heatmap/slicer.py
+++ b/brainglobe_heatmap/slicer.py
@@ -136,7 +136,7 @@ class Slicer:
         Slices the meshes in a 3D brainrender scene using the gien planes
         """
         # slice the scene
-        for n, plane in enumerate((self.plane0, self.plane1)):
+        for _, plane in enumerate((self.plane0, self.plane1)):
             scene.slice(plane, actors=regions, close_actors=True)
 
         scene.slice(self.plane0, actors=scene.root, close_actors=False)

--- a/examples/cellfinder_cell_density.py
+++ b/examples/cellfinder_cell_density.py
@@ -39,7 +39,7 @@ cell_counts = cell_counts.loc[cell_counts.density > 5 * 1e-9]
 print(cell_counts)
 
 
-f = bgh.heatmap(
+f = bgh.Heatmap(
     cell_counts.density.to_dict(),
     position=(
         8000,

--- a/examples/cellfinder_cell_density.py
+++ b/examples/cellfinder_cell_density.py
@@ -4,6 +4,8 @@
     density (count/volume) of cells in each brain region
 """
 
+from pathlib import Path
+
 import pandas as pd
 from brainglobe_atlasapi.bg_atlas import BrainGlobeAtlas
 from brainrender._io import load_mesh_from_file
@@ -11,7 +13,9 @@ from brainrender._io import load_mesh_from_file
 import brainglobe_heatmap as bgh
 
 # get the number of cells for each region
-data = pd.read_hdf("examples/cell_counts_example.h5")
+cells_path = Path(__file__).parent / "cell_counts_example.h5"
+
+data = pd.read_hdf(cells_path)
 cell_counts = data.groupby("region").count()
 
 # get regions two levels up the hierarchy

--- a/examples/heatmap_2d.py
+++ b/examples/heatmap_2d.py
@@ -23,7 +23,7 @@ values = dict(  # scalar values for each region
 )
 
 
-f = bgh.heatmap(
+f = bgh.Heatmap(
     values,
     # when using a named orientation, you can pass a single value!
     position=5000,

--- a/examples/heatmap_3d.py
+++ b/examples/heatmap_3d.py
@@ -23,7 +23,7 @@ values = dict(  # scalar values for each region
 )
 
 
-scene = bgh.heatmap(
+scene = bgh.Heatmap(
     values,
     position=(8000, 5000, 5000),
     orientation="frontal",  # or 'sagittal', or 'horizontal' or a tuple (x,y,z)

--- a/examples/heatmap_human_brain.py
+++ b/examples/heatmap_human_brain.py
@@ -10,7 +10,7 @@ import brainglobe_heatmap as bgh
 values = dict(SFG=1, PrCG=2, Ca=4, Pu=10)  # scalar values for each region
 
 
-scene = bgh.heatmap(
+scene = bgh.Heatmap(
     values,
     position=(100000, 100000, 100000),
     thickness=1000,

--- a/examples/heatmap_spinal_cord.py
+++ b/examples/heatmap_spinal_cord.py
@@ -19,7 +19,7 @@ values = {
 }
 
 
-f = bgh.heatmap(
+f = bgh.Heatmap(
     values,
     position=1000,
     # 'frontal' or 'sagittal', or 'horizontal' or a tuple (x,y,z)

--- a/examples/heatmap_zebrafish.py
+++ b/examples/heatmap_zebrafish.py
@@ -20,7 +20,7 @@ values = {
     "cerebellum": 0.5,
 }
 
-f = bgh.heatmap(
+f = bgh.Heatmap(
     values,
     position=175,
     # 'frontal' or 'sagittal', or 'horizontal' or a tuple (x,y,z)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ exclude = ["__init__.py", "build", ".eggs"]
 fix = true
 
 [tool.ruff.lint]
-select = ["I", "E", "F"]
+select = ["I", "E", "F", "B"]
 
 [tool.tox]
 legacy_tox_ini = """


### PR DESCRIPTION
- Capitalises classes (closes #41)
- Adds an extra ruff rule (seems like a good idea to add them to small codebases before it becomes onerous to add)
- Uses pathlib in the cell count example
- Removes another leftover script in a submodule