### PR TITLE
fixed a bug where horizontal Slicer would invert y axis projections

### DIFF
--- a/brainglobe_heatmap/slicer.py
+++ b/brainglobe_heatmap/slicer.py
@@ -38,7 +38,7 @@ class Slicer:
         if position is None:
             position = root.center_of_mass()
 
-        if isinstance(position, (float, int)):
+        if isinstance(position, (float, int, np.number)):
             if isinstance(orientation, str):
                 pval = position
                 position = root.center_of_mass()
@@ -68,7 +68,7 @@ class Slicer:
             elif orientation == "sagittal":
                 u0, v0 = np.array([[1, 0, 0], [0, 1, 0]])
             else:  # orientation == "horizontal"
-                u0, v0 = np.array([[0, 0, -1], [-1, 0, 0]])
+                u0, v0 = np.array([[0, 0, 1], [1, 0, 0]])
             plane0 = Plane(position, u0, v0)
             u1, v1 = u0.copy(), -v0.copy()  # set u1:=u0 and v1:=-v0
             plane1 = Plane(p1, u1, v1)


### PR DESCRIPTION
"horizontal" orientation is rarely used, but when using displaying the zebrafish brain for an internal demonstration i think i found that the Y axis was inverted resulting in a projection that had some dis-orienteering results.

Additionally i added the possibility to create a `Slicer` by giving a position that is a `numpy.number` as well

## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Allow better interoperability with scientific code using numpy and keeping a consistent visualization of the projected cutting planes

## Is this a breaking change?

no

## Does this PR require an update to the documentation?

no

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
