### PR TITLE
Add ax arg to plot method

### DIFF
--- a/brainglobe_heatmap/heatmaps.py
+++ b/brainglobe_heatmap/heatmaps.py
@@ -178,7 +178,7 @@ class Heatmap:
         hide_axes: bool = False,
         filename: Optional[str] = None,
         cbar_label: Optional[str] = None,
-        ax: Optional[plt.Axes] = None,,
+        ax: Optional[plt.Axes] = None,
         **kwargs,
     ) -> plt.Figure:
         """

--- a/brainglobe_heatmap/heatmaps.py
+++ b/brainglobe_heatmap/heatmaps.py
@@ -262,5 +262,6 @@ class Heatmap:
 
         if ax is None:
             plt.show()
-
+            return f
+            
         return ax

--- a/brainglobe_heatmap/heatmaps.py
+++ b/brainglobe_heatmap/heatmaps.py
@@ -191,7 +191,9 @@ class Heatmap:
 
         if ax is None:
             f, ax = plt.subplots(figsize=(9, 9))
+            internal_ax = True
         else:
+            internal_ax = False
             f = plt.gcf()
 
         for r, coords in projected.items():
@@ -260,7 +262,7 @@ class Heatmap:
         if show_legend:
             ax.legend()
 
-        if ax is None:
+        if internal_ax is True:
             plt.show()
             return f
 

--- a/brainglobe_heatmap/heatmaps.py
+++ b/brainglobe_heatmap/heatmaps.py
@@ -178,23 +178,123 @@ class Heatmap:
         hide_axes: bool = False,
         filename: Optional[str] = None,
         cbar_label: Optional[str] = None,
-        ax: Optional[plt.Axes] = None,
         show_cbar: bool = True,
         **kwargs,
     ) -> plt.Figure:
         """
-        Plots the heatmap in 2D using matplotlib
+        Plots the heatmap in 2D using matplotlib.
+
+        This method generates a 2D visualization of the heatmap data in
+        a standalone matplotlib figure.
+
+        Parameters
+        ----------
+        show_legend : bool, optional
+            If True, displays a legend for the plotted regions.
+            Default is False.
+        xlabel : str, optional
+            Label for the x-axis. Default is "µm".
+        ylabel : str, optional
+            Label for the y-axis. Default is "µm".
+        hide_axes : bool, optional
+            If True, hides the axes for a cleaner look. Default is False.
+        filename : Optional[str], optional
+            Path to save the figure to. If None, the figure is not saved.
+            Default is None.
+        cbar_label : Optional[str], optional
+            Label for the colorbar. If None, no label is displayed.
+            Default is None.
+        show_cbar : bool, optional
+            If True, displays a colorbar alongside the subplot.
+            Default is True.
+        **kwargs : dict
+            Additional keyword arguments passed to the plotting function.
+
+        Returns
+        -------
+        plt.Figure
+            The matplotlib figure object for the plot.
+
+        Notes
+        -----
+        This method is used to generate a standalone plot of
+        the heatmap data.
+        """
+
+        f, ax = plt.subplots(figsize=(9, 9))
+
+        f, ax = self.plot_subplot(
+            fig=f,
+            ax=ax,
+            show_legend=show_legend,
+            xlabel=xlabel,
+            ylabel=ylabel,
+            hide_axes=hide_axes,
+            cbar_label=cbar_label,
+            show_cbar=show_cbar,
+            **kwargs,
+        )
+
+        if filename is not None:
+            plt.savefig(filename, dpi=300)
+
+        plt.show()
+        return f
+
+    def plot_subplot(
+        self,
+        fig: plt.Figure,
+        ax: plt.Axes,
+        show_legend: bool = False,
+        xlabel: str = "µm",
+        ylabel: str = "µm",
+        hide_axes: bool = False,
+        cbar_label: Optional[str] = None,
+        show_cbar: bool = True,
+        **kwargs,
+    ) -> Tuple[plt.Figure, plt.Axes]:
+        """
+        Plots a heatmap in a subplot within a given figure and axes.
+
+        This method is responsible for plotting a single subplot within a
+        larger figure, allowing for the creation of complex multi-plot
+        visualizations.
+
+        Parameters
+        ----------
+        fig : plt.Figure, optional
+            The figure object in which the subplot is plotted.
+        ax : plt.Axes, optional
+            The axes object in which the subplot is plotted.
+        show_legend : bool, optional
+            If True, displays a legend for the plotted regions.
+            Default is False.
+        xlabel : str, optional
+            Label for the x-axis. Default is "µm".
+        ylabel : str, optional
+            Label for the y-axis. Default is "µm".
+        hide_axes : bool, optional
+            If True, hides the axes for a cleaner look. Default is False.
+        cbar_label : Optional[str], optional
+            Label for the colorbar. If None, no label is displayed.
+            Default is None.
+        show_cbar : bool, optional
+            Display a colorbar alongside the subplot. Default is True.
+        **kwargs : dict
+            Additional keyword arguments passed to the plotting function.
+
+        Returns
+        -------
+        plt.Figure, plt.Axes
+            A tuple containing the figure and axes objects used for the plot.
+
+        Notes
+        -----
+        This method modifies the provided figure and axes objects in-place.
         """
         projected, _ = self.slicer.get_structures_slice_coords(
             self.regions_meshes, self.scene.root
         )
-
-        if ax is None:
-            f, ax = plt.subplots(figsize=(9, 9))
-            internal_ax = True
-        else:
-            internal_ax = False
-            f = plt.gcf()
 
         for r, coords in projected.items():
             name, segment = r.split("_segment_")
@@ -217,7 +317,7 @@ class Heatmap:
             # cmap = mpl.cm.cool
             norm = mpl.colors.Normalize(vmin=self.vmin, vmax=self.vmax)
             if self.label_regions is True:
-                cbar = f.colorbar(
+                cbar = fig.colorbar(
                     mpl.cm.ScalarMappable(
                         norm=None,
                         cmap=mpl.cm.get_cmap(self.cmap, len(self.values)),
@@ -225,7 +325,7 @@ class Heatmap:
                     cax=cax,
                 )
             else:
-                cbar = f.colorbar(
+                cbar = fig.colorbar(
                     mpl.cm.ScalarMappable(norm=norm, cmap=self.cmap), cax=cax
                 )
 
@@ -256,14 +356,7 @@ class Heatmap:
             ax.set_yticks([])
             ax.set(xlabel="", ylabel="")
 
-        if filename is not None:
-            plt.savefig(filename, dpi=300)
-
         if show_legend:
             ax.legend()
 
-        if internal_ax is True:
-            plt.show()
-            return f
-
-        return ax
+        return fig, ax

--- a/brainglobe_heatmap/heatmaps.py
+++ b/brainglobe_heatmap/heatmaps.py
@@ -173,11 +173,12 @@ class Heatmap:
     def plot(
         self,
         show_legend: bool = False,
-        xlabel: str = "μm",
-        ylabel: str = "μm",
+        xlabel: str = "??m",
+        ylabel: str = "??m",
         hide_axes: bool = False,
         filename: Optional[str] = None,
         cbar_label: Optional[str] = None,
+        ax: Optional[plt.Axes] = None,,
         **kwargs,
     ) -> plt.Figure:
         """
@@ -187,7 +188,11 @@ class Heatmap:
             self.regions_meshes, self.scene.root
         )
 
-        f, ax = plt.subplots(figsize=(9, 9))
+        if ax == None:
+            f, ax = plt.subplots(figsize=(9, 9))
+        else:
+            f = plt.gcf()
+
         for r, coords in projected.items():
             name, segment = r.split("_segment_")
             ax.fill(
@@ -250,6 +255,6 @@ class Heatmap:
 
         if show_legend:
             ax.legend()
-        plt.show()
+        #plt.show()
 
-        return f
+        return ax

--- a/brainglobe_heatmap/heatmaps.py
+++ b/brainglobe_heatmap/heatmaps.py
@@ -263,5 +263,5 @@ class Heatmap:
         if ax is None:
             plt.show()
             return f
-            
+
         return ax

--- a/brainglobe_heatmap/heatmaps.py
+++ b/brainglobe_heatmap/heatmaps.py
@@ -259,6 +259,8 @@ class Heatmap:
 
         if show_legend:
             ax.legend()
-        # plt.show()
+        
+        if ax is None:
+            plt.show()
 
         return ax

--- a/brainglobe_heatmap/heatmaps.py
+++ b/brainglobe_heatmap/heatmaps.py
@@ -211,7 +211,7 @@ class Heatmap:
             # make colorbar
             divider = make_axes_locatable(ax)
             cax = divider.append_axes("right", size="5%", pad=0.05)
-    
+
             # cmap = mpl.cm.cool
             norm = mpl.colors.Normalize(vmin=self.vmin, vmax=self.vmax)
             if self.label_regions is True:
@@ -226,12 +226,14 @@ class Heatmap:
                 cbar = f.colorbar(
                     mpl.cm.ScalarMappable(norm=norm, cmap=self.cmap), cax=cax
                 )
-    
+
             if cbar_label is not None:
                 cbar.set_label(cbar_label)
-    
+
             if self.label_regions is True:
-                cbar.ax.set_yticklabels([r.strip() for r in self.values.keys()])
+                cbar.ax.set_yticklabels(
+                    [r.strip() for r in self.values.keys()]
+                )
 
         # style axes
         ax.invert_yaxis()

--- a/brainglobe_heatmap/heatmaps.py
+++ b/brainglobe_heatmap/heatmaps.py
@@ -259,7 +259,7 @@ class Heatmap:
 
         if show_legend:
             ax.legend()
-        
+
         if ax is None:
             plt.show()
 

--- a/brainglobe_heatmap/heatmaps.py
+++ b/brainglobe_heatmap/heatmaps.py
@@ -189,7 +189,7 @@ class Heatmap:
             self.regions_meshes, self.scene.root
         )
 
-        if ax == None:
+        if ax is None:
             f, ax = plt.subplots(figsize=(9, 9))
         else:
             f = plt.gcf()

--- a/brainglobe_heatmap/heatmaps.py
+++ b/brainglobe_heatmap/heatmaps.py
@@ -179,6 +179,7 @@ class Heatmap:
         filename: Optional[str] = None,
         cbar_label: Optional[str] = None,
         ax: Optional[plt.Axes] = None,
+        show_cbar: bool = True,
         **kwargs,
     ) -> plt.Figure:
         """
@@ -206,30 +207,31 @@ class Heatmap:
                 alpha=0.3 if name == "root" else None,
             )
 
-        # make colorbar
-        divider = make_axes_locatable(ax)
-        cax = divider.append_axes("right", size="5%", pad=0.05)
-
-        # cmap = mpl.cm.cool
-        norm = mpl.colors.Normalize(vmin=self.vmin, vmax=self.vmax)
-        if self.label_regions is True:
-            cbar = f.colorbar(
-                mpl.cm.ScalarMappable(
-                    norm=None,
-                    cmap=mpl.cm.get_cmap(self.cmap, len(self.values)),
-                ),
-                cax=cax,
-            )
-        else:
-            cbar = f.colorbar(
-                mpl.cm.ScalarMappable(norm=norm, cmap=self.cmap), cax=cax
-            )
-
-        if cbar_label is not None:
-            cbar.set_label(cbar_label)
-
-        if self.label_regions is True:
-            cbar.ax.set_yticklabels([r.strip() for r in self.values.keys()])
+        if show_cbar:
+            # make colorbar
+            divider = make_axes_locatable(ax)
+            cax = divider.append_axes("right", size="5%", pad=0.05)
+    
+            # cmap = mpl.cm.cool
+            norm = mpl.colors.Normalize(vmin=self.vmin, vmax=self.vmax)
+            if self.label_regions is True:
+                cbar = f.colorbar(
+                    mpl.cm.ScalarMappable(
+                        norm=None,
+                        cmap=mpl.cm.get_cmap(self.cmap, len(self.values)),
+                    ),
+                    cax=cax,
+                )
+            else:
+                cbar = f.colorbar(
+                    mpl.cm.ScalarMappable(norm=norm, cmap=self.cmap), cax=cax
+                )
+    
+            if cbar_label is not None:
+                cbar.set_label(cbar_label)
+    
+            if self.label_regions is True:
+                cbar.ax.set_yticklabels([r.strip() for r in self.values.keys()])
 
         # style axes
         ax.invert_yaxis()

--- a/brainglobe_heatmap/heatmaps.py
+++ b/brainglobe_heatmap/heatmaps.py
@@ -173,8 +173,8 @@ class Heatmap:
     def plot(
         self,
         show_legend: bool = False,
-        xlabel: str = "??m",
-        ylabel: str = "??m",
+        xlabel: str = "µm",
+        ylabel: str = "µm",
         hide_axes: bool = False,
         filename: Optional[str] = None,
         cbar_label: Optional[str] = None,

--- a/brainglobe_heatmap/heatmaps.py
+++ b/brainglobe_heatmap/heatmaps.py
@@ -255,6 +255,6 @@ class Heatmap:
 
         if show_legend:
             ax.legend()
-        #plt.show()
+        # plt.show()
 
         return ax

--- a/brainglobe_heatmap/heatmaps.py
+++ b/brainglobe_heatmap/heatmaps.py
@@ -52,7 +52,7 @@ class Heatmap:
     def __init__(
         self,
         values: Dict,
-        position: Union[list, tuple, np.ndarray],
+        position: Union[list, tuple, np.ndarray, float],
         orientation: Union[str, tuple] = "frontal",
         hemisphere: str = "both",
         title: Optional[str] = None,

--- a/examples/heatmap_2d_subplots.py
+++ b/examples/heatmap_2d_subplots.py
@@ -13,6 +13,9 @@ data_dict = {
     "VISam": 1.0,
 }
 
+# Create a list of scenes to plot
+# Note: it's important to keep reference to the scenes to avoid a
+# segmentation fault
 scenes = []
 for distance in range(7500, 10500, 500):
     scene = bgh.Heatmap(
@@ -28,6 +31,7 @@ for distance in range(7500, 10500, 500):
     )
     scenes.append(scene)
 
+# Create a figure with 6 subplots and plot the scenes
 fig, axs = plt.subplots(3, 2, figsize=(18, 12))
 for scene, ax in zip(scenes, axs.flatten()):
     scene.plot_subplot(fig=fig, ax=ax, show_cbar=True, hide_axes=False)

--- a/examples/heatmap_2d_subplots.py
+++ b/examples/heatmap_2d_subplots.py
@@ -1,0 +1,36 @@
+import matplotlib.pyplot as plt
+
+import brainglobe_heatmap as bgh
+
+data_dict = {
+    "VISpm": 0.0,
+    "VISp": 0.14285714285714285,
+    "VISl": 0.2857142857142857,
+    "VISli": 0.42857142857142855,
+    "VISal": 0.5714285714285714,
+    "VISrl": 0.7142857142857142,
+    "SSp-bfd": 0.8571428571428571,
+    "VISam": 1.0,
+}
+
+scenes = []
+for distance in range(7500, 10500, 500):
+    scene = bgh.Heatmap(
+        data_dict,
+        position=distance,
+        orientation="frontal",
+        thickness=10,
+        format="2D",
+        cmap="Reds",
+        vmin=0,
+        vmax=1,
+        label_regions=False,
+    )
+    scenes.append(scene)
+
+fig, axs = plt.subplots(3, 2, figsize=(18, 12))
+for scene, ax in zip(scenes, axs.flatten()):
+    scene.plot_subplot(fig=fig, ax=ax, show_cbar=True, hide_axes=False)
+
+plt.tight_layout()
+plt.show()


### PR DESCRIPTION
- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

I would like to be able to do something like this:
```

fig, axs = plt.subplots(1,3, figsize=(15,4))
for ax, d in zip(axs,[8800, 9300, 9700]):
    scene = bgh.Heatmap(
        regions,
        position=(d),
        orientation="frontal",  # or 'sagittal', or 'horizontal' or a tuple (x,y,z)
        thickness=10,
        title="frontal",
        format="2D",
    )
    scene.plot(ax=ax)
```
<img width="1248" alt="Screenshot 2024-05-30 at 15 38 22" src="https://github.com/brainglobe/brainglobe-heatmap/assets/37729096/99379da6-2142-4389-8aa0-10394f1c55a1">

Is there a better way to achieve this?

Thanks!


## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
