### PR TITLE
Specify brainrender version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dynamic = ["version"]
 
-dependencies = ["brainrender", "matplotlib", "numpy", "myterial", "rich"]
+dependencies = ["brainrender>=2.1.9", "matplotlib", "numpy", "myterial", "rich"]
 
 license = { text = "MIT" }
 


### PR DESCRIPTION
This package is very closely aligned with brainrender, so it makes sense to make sure the brainrender version is up to date. 