### PR TITLE
add camera option to Heatmap.render()

### DIFF
--- a/brainglobe_heatmap/heatmaps.py
+++ b/brainglobe_heatmap/heatmaps.py
@@ -134,9 +134,19 @@ class Heatmap:
             view = self.plot(**kwargs)
         return view
 
-    def render(self, camera=None, **kwargs) -> Scene:
+    def render(self, camera=None) -> Scene:
         """
-        Renders the hetamap visualization as a 3D scene in brainrender.
+        Renders the heatmap visualization as a 3D scene in brainrender.
+
+        Parameters:
+        ----------
+        camera : str or dict, optional
+            The `brainrender` camera to render the scene.
+            If not provided, `self.orientation` is used.
+        Returns:
+        -------
+        scene : Scene
+            The rendered 3D scene.
         """
 
         # set brain regions colors

--- a/brainglobe_heatmap/heatmaps.py
+++ b/brainglobe_heatmap/heatmaps.py
@@ -134,7 +134,7 @@ class Heatmap:
             view = self.plot(**kwargs)
         return view
 
-    def render(self, **kwargs) -> Scene:
+    def render(self, camera=None, **kwargs) -> Scene:
         """
         Renders the hetamap visualization as a 3D scene in brainrender.
         """
@@ -148,22 +148,23 @@ class Heatmap:
                 0
             ].color(color)
 
-        # set camera position and render
-        if isinstance(self.orientation, str):
-            if self.orientation == "sagittal":
-                camera = cameras.sagittal_camera2
-            elif self.orientation == "horizontal":
-                camera = "top"
+        if camera is None:
+            # set camera position and render
+            if isinstance(self.orientation, str):
+                if self.orientation == "sagittal":
+                    camera = cameras.sagittal_camera2
+                elif self.orientation == "horizontal":
+                    camera = "top"
+                else:
+                    camera = self.orientation
             else:
-                camera = self.orientation
-        else:
-            self.orientation = np.array(self.orientation)
-            com = self.slicer.plane0.center_of_mass()
-            camera = {
-                "pos": com - self.orientation * 2 * np.linalg.norm(com),
-                "viewup": (0, -1, 0),
-                "clipping_range": (19531, 40903),
-            }
+                self.orientation = np.array(self.orientation)
+                com = self.slicer.plane0.center_of_mass()
+                camera = {
+                    "pos": com - self.orientation * 2 * np.linalg.norm(com),
+                    "viewup": (0, -1, 0),
+                    "clipping_range": (19531, 40903),
+                }
 
         self.scene.render(
             camera=camera, interactive=self.interactive, zoom=self.zoom


### PR DESCRIPTION
simple option to add camera positioning when rendering 3D heatmaps