### PR TITLE
Update orientation for allen cord example

### DIFF
--- a/examples/heatmap_spinal_cord.py
+++ b/examples/heatmap_spinal_cord.py
@@ -23,7 +23,7 @@ f = bgh.Heatmap(
     values,
     position=1000,
     # 'frontal' or 'sagittal', or 'horizontal' or a tuple (x,y,z)
-    orientation="sagittal",
+    orientation="frontal",
     thickness=1000,
     atlas_name="allen_cord_20um",
     format="2D",


### PR DESCRIPTION
Now the allen cord atlas has been updated, and the meshes are in the correct orientation, this example needs to be updated. The saggital orientation didn't make much sense for the cord example. This new script makes the [figure as expected](https://forum.image.sc/t/allen-spinal-cord-atlas-appears-disfigured-in-python/99256):
![Screenshot from 2024-07-22 12-29-34](https://github.com/user-attachments/assets/b81a5228-5efa-4a5f-86d1-9578e5d78f01)
