### PR TITLE
Enforce latest version of brainrender

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dynamic = ["version"]
 
-dependencies = ["brainrender>=2.1.9", "matplotlib", "numpy", "myterial", "rich"]
+dependencies = ["brainrender>=2.1.11", "matplotlib", "numpy", "myterial", "rich"]
 
 license = { text = "MIT" }
 


### PR DESCRIPTION
To ensure that the hemisphere option works properly (at least with the properly structured atlases). 