### PR TITLE
Fix slicer pre-transforming the planes' center

### DIFF
--- a/brainglobe_heatmap/planner.py
+++ b/brainglobe_heatmap/planner.py
@@ -75,7 +75,7 @@ class plan(Heatmap):
         print_plane("Plane 0", self.slicer.plane0, blue_dark)
         print_plane("Plane 1", self.slicer.plane1, pink_dark)
 
-    def show(self):
+    def show(self, both=True):
         """
         Renders the hetamap visualization as a 3D scene in brainrender.
         """
@@ -88,7 +88,11 @@ class plan(Heatmap):
 
         # add slicing planes and their norms
         for plane, color, alpha in zip(
-            (self.slicer.plane0, self.slicer.plane1),
+            (
+                (self.slicer.plane0, self.slicer.plane1)
+                if both
+                else (self.slicer.plane0,)
+            ),
             (blue_dark, pink_dark),
             (0.8, 0.3),
             strict=False,
@@ -96,7 +100,7 @@ class plan(Heatmap):
             plane_mesh = plane.to_mesh(self.scene.root)
             plane_mesh.alpha(alpha).color(color)
 
-            self.scene.add(plane_mesh, transform=False)
+            self.scene.add(plane_mesh)
             for vector, v_color in zip(
                 (plane.normal, plane.u, plane.v),
                 (color, red_dark, green_dark),
@@ -109,12 +113,12 @@ class plan(Heatmap):
                         + np.array(vector) * self.arrow_scale,
                         c=v_color,
                     ),
-                    transform=False,
+                    classes=plane_mesh.br_class,
                 )
 
             self.scene.add(
                 Sphere(plane_mesh.center, r=plane_mesh.width / 125, c="k"),
-                transform=False,
+                classes=plane_mesh.br_class,
             )
 
         self.scene.render(interactive=self.interactive, zoom=self.zoom)

--- a/brainglobe_heatmap/slicer.py
+++ b/brainglobe_heatmap/slicer.py
@@ -51,7 +51,6 @@ class Slicer:
                 )
 
         position = np.array(position)
-        position[2] = -position[2]
 
         if isinstance(orientation, str):
             axidx = get_ax_idx(orientation)


### PR DESCRIPTION
The `Slicer` automatically set the centre x positioning to its negative value.
This, however, is not something whose responsibility is of the constructor, but rather of the renderer.
As a consequence, it required some weird problems when messing with slicers' planes.

Additionally, it adds the parameter `both` to `plan.show()`.

## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

## How has this PR been tested?

```python
from brainrender import Atlas, settings

import brainglobe_heatmap as bgh
import numpy as np

settings.SHOW_AXES = True

atlas = Atlas(atlas_name="allen_mouse_25um")
center = np.array([100, 100, 100])
slicer = bgh.slicer.Slicer(center, "frontal", 10, atlas.get_region("root"))
assert all(slicer.plane0.center == center)
```

## Is this a breaking change?

no

## Does this PR require an update to the documentation?

no

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
