### PR TITLE
Resolve polygon overlay issues 2D

### DIFF
--- a/brainglobe_heatmap/heatmaps.py
+++ b/brainglobe_heatmap/heatmaps.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union, cast
 
 import matplotlib as mpl
 import matplotlib.pyplot as plt
@@ -354,7 +354,9 @@ class Heatmap:
         )
 
         root_segments = []
-        region_areas: Dict[str, Dict[str, Any]] = {}
+        region_areas: Dict[
+            str, Dict[str, Union[float, List[Tuple[str, np.ndarray]]]]
+        ] = {}
         for r, coords in projected.items():
             name, segment = r.split("_segment_")
             if name == "root":
@@ -369,7 +371,11 @@ class Heatmap:
 
             if name in region_areas:
                 region_areas[name]["area"] += area
-                region_areas[name]["segments"].append((r, coords))
+                segments = cast(
+                    List[Tuple[str, np.ndarray]],
+                    region_areas[name]["segments"],
+                )
+                segments.append((r, coords))
             else:
                 region_areas[name] = {"area": area, "segments": [(r, coords)]}
 
@@ -396,7 +402,11 @@ class Heatmap:
 
         # regions
         for region_name in sorted_regions_by_area:
-            for r, coords in region_areas[region_name]["segments"]:
+            segments = cast(
+                List[Tuple[str, np.ndarray]],
+                region_areas[region_name]["segments"],
+            )
+            for r, coords in segments:
                 name, segment = r.split("_segment_")
                 ax.fill(
                     coords[:, 0],

--- a/brainglobe_heatmap/heatmaps.py
+++ b/brainglobe_heatmap/heatmaps.py
@@ -358,6 +358,7 @@ class Heatmap:
             name, segment_nr = r.split("_segment_")
             x = coords[:, 0]
             y = coords[:, 1]
+            # calculate area of polygon with Shoelace formula
             area = 0.5 * np.abs(
                 np.dot(x, np.roll(y, 1)) - np.dot(y, np.roll(x, 1))
             )


### PR DESCRIPTION
## Implement consistent ax.fill

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Depending on the order of the input values dict, some region boundaries and colors may not be displayed.

**What does this PR do?**

Sort ax.fill order by area.

## References

#78 

## How has this PR been tested?

```python
f = bgh.Heatmap(
    values,
    position=160,
    # 'frontal' or 'sagittal', or 'horizontal' or a tuple (x,y,z)
    orientation="horizontal",
    thickness=250,
    atlas_name="mpin_zfish_1um",
    format="2D",
    title="zebra fish heatmap",
).show(xlabel="AP (μm)", ylabel="DV (μm)")
```
- values = { "medial tegmentum": 3, "oculomotor nucleus": 5, "tegmentum": 0 }

| Before | After  |
|---------------------------|---------------------------|
| ![zebra_before](https://github.com/user-attachments/assets/7564a5fd-79f0-4f64-a698-17432b43e4f7) | ![zebra_fix_2](https://github.com/user-attachments/assets/14b76454-9bca-477c-b1e4-dfc52e1b90d9) |

## Is this a breaking change?

Not sure.

## Does this PR require an update to the documentation?

No

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
