### PR TITLE
support for multiple slice positions in 2D heatmaps with automatic layout

### DIFF
--- a/brainglobe_heatmap/planner.py
+++ b/brainglobe_heatmap/planner.py
@@ -72,6 +72,10 @@ class plan(Heatmap):
         )
 
         # print planes information
+        assert self.slicer is not None, (
+            "Cannot access plane0/plane1: slicer is None, "
+            "check your position parameter"
+        )
         print_plane("Plane 0", self.slicer.plane0, blue_dark)
         print_plane("Plane 1", self.slicer.plane1, pink_dark)
 

--- a/examples/heatmap_2d_subplots.py
+++ b/examples/heatmap_2d_subplots.py
@@ -1,5 +1,3 @@
-import matplotlib.pyplot as plt
-
 import brainglobe_heatmap as bgh
 
 data_dict = {
@@ -13,28 +11,14 @@ data_dict = {
     "VISam": 1.0,
 }
 
-# Create a list of scenes to plot
-# Note: it's important to keep reference to the scenes to avoid a
-# segmentation fault
-scenes = []
-for distance in range(7500, 10500, 500):
-    scene = bgh.Heatmap(
-        data_dict,
-        position=distance,
-        orientation="frontal",
-        thickness=10,
-        format="2D",
-        cmap="Reds",
-        vmin=0,
-        vmax=1,
-        label_regions=False,
-    )
-    scenes.append(scene)
-
-# Create a figure with 6 subplots and plot the scenes
-fig, axs = plt.subplots(3, 2, figsize=(18, 12))
-for scene, ax in zip(scenes, axs.flatten(), strict=False):
-    scene.plot_subplot(fig=fig, ax=ax, show_cbar=True, hide_axes=False)
-
-plt.tight_layout()
-plt.show()
+f = bgh.Heatmap(
+    data_dict,
+    position=[7000, 7250, 7500, 8000, 8500, 9000, 9500, 10000],
+    orientation="frontal",
+    cmap="Reds",
+    vmin=0,
+    vmax=1,
+    title="",  # title=None for title with positions number
+    label_regions=False,
+    format="2D",
+).show(filename="saved_picture", show_cbar=True, hide_axes=False)

--- a/examples/heatmap_2d_subplots.py
+++ b/examples/heatmap_2d_subplots.py
@@ -21,4 +21,4 @@ f = bgh.Heatmap(
     title="",  # title=None for title with positions number
     label_regions=False,
     format="2D",
-).show(filename="saved_picture", show_cbar=True, hide_axes=False)
+).show(show_cbar=True, hide_axes=False)


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Addition of a new feature

**Why is this PR needed?**

solves #54 

**What does this PR do?**
- Allow position parameter to accept a list of positions in 2D format
- Generate plt.Figure with up to 25 positions each in a grid layout.

**Example**
| | | |
| -------- | -------- | -------- |
| ![picture](https://github.com/user-attachments/assets/3350393f-e450-49bd-a62b-24adf335e897) | ![picture_25](https://github.com/user-attachments/assets/a4933fba-b4a0-451b-9f91-c85e04637d07) | ![picture_25_hides](https://github.com/user-attachments/assets/413ff821-a198-49f2-a00e-d6090bd48745) |

## Is this a breaking change?
No

## Does this PR require an update to the documentation?
no

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
