### PR TITLE
Update README.md with new badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Python Version](https://img.shields.io/pypi/pyversions/brainglobe-heatmap.svg)](https://pypi.org/project/brainglobe-heatmap)
 [![PyPI](https://img.shields.io/pypi/v/brainglobe-heatmap.svg)](https://pypi.org/project/brainglobe-heatmap)
-[![Napari hub](https://img.shields.io/endpoint?url=https://npe2api-git-add-shields-napari.vercel.app/api/shields/brainglobe-segmentation)](https://napari-hub.org/plugins/brainglobe-segmentation.html)
+[![Napari hub](https://img.shields.io/endpoint?url=https://npe2api-git-add-shields-napari.vercel.app/api/shields/brainglobe-heatmap)](https://napari-hub.org/plugins/brainglobe-heatmap.html)
 [![Downloads](https://pepy.tech/badge/brainglobe-heatmap)](https://pepy.tech/project/brainglobe-heatmap)
 [![Wheel](https://img.shields.io/pypi/wheel/brainglobe-heatmap.svg)](https://pypi.org/project/brainglobe-heatmap)
 [![Development Status](https://img.shields.io/pypi/status/brainglobe-heatmap.svg)](https://github.com/brainglobe/brainglobe-heatmap)


### PR DESCRIPTION
Following up  on https://github.com/brainglobe/cellfinder/pull/563

Changes include:

- Adding the napari hub badge back
- Changing the code style badge from black to ruff
- Adding a badge linking to the image.sc forum (shamelessly stolen from https://github.com/napari)
- Changed the social media badges from X to bluesky and mastodon