### PR TITLE
Fix: 2D coords into atlas space

### DIFF
--- a/brainglobe_heatmap/plane.py
+++ b/brainglobe_heatmap/plane.py
@@ -1,5 +1,3 @@
-from typing import Dict, List
-
 import numpy as np
 import vedo as vd
 import vtkmodules.all as vtk
@@ -66,22 +64,3 @@ class Plane:
         return mesh.intersect_with_plane(
             origin=self.center, normal=self.normal
         )
-
-    # for Slicer.get_structures_slice_coords()
-    def get_projections(
-        self, actors: List[Actor], project_fn=None
-    ) -> Dict[str, np.ndarray]:
-        projected = {}
-        for actor in actors:
-            mesh: vd.Mesh = actor._mesh
-            intersection = self.intersect_with(mesh)
-            if not intersection.vertices.shape[0]:
-                continue
-            pieces = intersection.split()  # intersection.split() in newer vedo
-            for piece_n, piece in enumerate(pieces):
-                # sort coordinates
-                points = piece.join(reset=True).vertices
-                projected[actor.name + f"_segment_{piece_n}"] = project_fn(
-                    points
-                )
-        return projected

--- a/brainglobe_heatmap/plane.py
+++ b/brainglobe_heatmap/plane.py
@@ -68,7 +68,9 @@ class Plane:
         )
 
     # for Slicer.get_structures_slice_coords()
-    def get_projections(self, actors: List[Actor]) -> Dict[str, np.ndarray]:
+    def get_projections(
+        self, actors: List[Actor], project_fn=None
+    ) -> Dict[str, np.ndarray]:
         projected = {}
         for actor in actors:
             mesh: vd.Mesh = actor._mesh
@@ -79,7 +81,7 @@ class Plane:
             for piece_n, piece in enumerate(pieces):
                 # sort coordinates
                 points = piece.join(reset=True).vertices
-                projected[actor.name + f"_segment_{piece_n}"] = self.p3_to_p2(
+                projected[actor.name + f"_segment_{piece_n}"] = project_fn(
                     points
                 )
         return projected

--- a/brainglobe_heatmap/slicer.py
+++ b/brainglobe_heatmap/slicer.py
@@ -138,9 +138,17 @@ class Slicer:
         """
         regions = regions + [root]
 
-        projected: Dict[str, np.ndarray] = self.plane0.get_projections(
-            regions, project_fn=self._project_to_2d
-        )
+        projected = {}
+        for actor in regions:
+            intersection = self.plane0.intersect_with(actor._mesh)
+            if not intersection.vertices.shape[0]:
+                continue
+            pieces = intersection.split()
+            for piece_n, piece in enumerate(pieces):
+                points = piece.join(reset=True).vertices
+                projected[actor.name + f"_segment_{piece_n}"] = (
+                    self._project_to_2d(points)
+                )
 
         # get output coordinates
         coordinates: Dict[str, List[np.ndarray]] = dict()

--- a/brainglobe_heatmap/slicer.py
+++ b/brainglobe_heatmap/slicer.py
@@ -92,6 +92,9 @@ class Slicer:
 
             # M based on dominant axis
             norm = orientation / np.linalg.norm(orientation)
+            # _project_to_2d unflips Z before projecting
+            # the effective normal in atlas space is (nx, ny, -nz)
+            norm[2] = -norm[2]  # atlas-space normal
             dominant = np.argmax(np.abs(orientation))
             if dominant == 0:  # frontal-like
                 u_proj = np.array([0.0, 0.0, 1.0])

--- a/examples/heatmap_2d_subplots_oblique.py
+++ b/examples/heatmap_2d_subplots_oblique.py
@@ -1,0 +1,61 @@
+"""
+This example shows named and oblique orientations side by side in subplots.
+"""
+
+import matplotlib.pyplot as plt
+
+import brainglobe_heatmap as bgh
+
+values = dict(  # scalar values for each region
+    TH=1,
+    RSP=0.2,
+    AI=0.4,
+    SS=-3,
+    MO=2.6,
+    PVZ=-4,
+    LZ=-3,
+    VIS=2,
+    AUD=0.3,
+    RHP=-0.2,
+    STR=0.5,
+    CB=0.5,
+    FRP=-1.7,
+    HIP=3,
+    PA=-4,
+)
+
+orientations_title = [
+    ("frontal", "frontal"),
+    ("horizontal", "horizontal"),
+    ("sagittal", "sagittal"),
+    ((1, 0, 0), "frontal (1, 0, 0)"),
+    ((0, 1, 0), "horizontal (0, 1, 0)"),
+    ((0, 0, 1), "sagittal (0, 0, 1)"),
+    ((1, 0, 0.3), "front tilted LR (1, 0, 0.3)"),
+    ((0, 1, 0.3), "horiz tilted LR (0, 1, 0.3)"),
+    ((0, 0.3, 1), "sagit tilted DV (0, 0.3 ,1)"),
+    ((1, 0.3, 0), "front tilted DV (1, 0.3, 0)"),
+    ((0.3, 1, 0), "horiz tilted AP (0.3, 1, 0)"),
+    ((0.3, 0, 1), "sagit tilted AP (0.3, 0, 1)"),
+]
+
+# Create all heatmap scenes first to avoid segmentation fault
+scenes = []
+for orient, title in orientations_title:
+    scene = bgh.Heatmap(
+        values,
+        position=(8000, 5000, 5000),
+        orientation=orient,  # type: ignore[arg-type]
+        title=title,  # type: ignore[arg-type]
+        vmin=-5,
+        vmax=3,
+        format="2D",
+    )
+    scenes.append(scene)
+
+fig, axs = plt.subplots(4, 3, figsize=(20, 28))
+for scene, ax in zip(scenes, axs.flatten(), strict=False):
+    scene.plot_subplot(fig=fig, ax=ax, show_cbar=True, hide_axes=False)
+
+plt.tight_layout()
+plt.show()

--- a/examples/slicer_2D.py
+++ b/examples/slicer_2D.py
@@ -33,12 +33,12 @@ f, ax = plt.subplots(figsize=(6, 9))
 plt.imshow(confocal_slice, cmap="gray_r")
 for struct_name, contours in coords_dict.items():
     for cont in contours:
-        plt.fill(cont[:, 0], -cont[:, 1], lw=1, fc="none", ec="k")
+        plt.fill(cont[:, 0], cont[:, 1], lw=1, fc="none", ec="k")
 
         # write outlined text to label each brain region
         txt = plt.text(
             cont[:, 0].mean(),
-            -cont[:, 1].mean(),
+            cont[:, 1].mean(),
             struct_name[:4] + ".",
             ha="center",
             va="center",

--- a/tests/test_integration/test_get_coordinates.py
+++ b/tests/test_integration/test_get_coordinates.py
@@ -103,3 +103,31 @@ def test_tuple_orientation_matches_named(orientation, region):
         f"{orientation}/{region}: named vs tuple coords differ. "
         f"max_dist={max_dist:.0f} µm, threshold={THRESHOLD_UM} µm"
     )
+
+
+# expects Z produce 2D spread on both axes by checking root.
+# a root can't be this ${MIN_SPREAD_UM} thin
+# can catch issues with norm
+@pytest.mark.parametrize(
+    "orientation", [(1, 1, 0), (1, 0, 1), (0, 1, 1), (0.3, 0.7, 1)]
+)
+def test_oblique_orientation_has_2d_spread(orientation):
+    MIN_SPREAD_UM = 500
+
+    coords = bgh.get_structures_slice_coords(
+        REGIONS, position=POSITION, orientation=orientation
+    )
+
+    root_pts = np.vstack(coords["root"])
+    spread = root_pts.max(axis=0) - root_pts.min(axis=0)
+
+    assert spread[0] > MIN_SPREAD_UM, (
+        f"orientation={orientation}: "
+        f"spread={spread[0]:.0f} µm "
+        f"(min {MIN_SPREAD_UM} µm expected)"
+    )
+    assert spread[1] > MIN_SPREAD_UM, (
+        f"orientation={orientation}: "
+        f"spread={spread[1]:.0f} µm "
+        f"(min {MIN_SPREAD_UM} µm expected)"
+    )

--- a/tests/test_integration/test_get_coordinates.py
+++ b/tests/test_integration/test_get_coordinates.py
@@ -1,0 +1,105 @@
+"""
+Tests output of `get_structures_slice_coords` VS annotation coords
+"""
+
+import numpy as np
+import pytest
+from brainglobe_atlasapi import BrainGlobeAtlas
+
+import brainglobe_heatmap as bgh
+
+ATLAS_NAME = "allen_mouse_25um"
+REGIONS = ["HIP"]
+POSITION = (8000, 5000, 5000)
+THRESHOLD_UM = 75  # 3 voxels at 25µm resolution
+
+
+@pytest.fixture(scope="module")
+def atlas():
+    return BrainGlobeAtlas(ATLAS_NAME, check_latest=False)
+
+
+# Expects that mesh coords match annotation coords
+@pytest.mark.parametrize("orientation", ["frontal", "horizontal", "sagittal"])
+@pytest.mark.parametrize("region", REGIONS)
+def test_mesh_coords_match_annotation(atlas, orientation, region):
+    ORIENTATION_TO_AXIS = {"frontal": 0, "horizontal": 1, "sagittal": 2}
+
+    atlas_resolution = atlas.resolution[0]
+
+    coords = bgh.get_structures_slice_coords(
+        [region], position=POSITION, orientation=orientation
+    )
+
+    # mesh - um
+    mesh_pts = np.vstack(coords[region])
+
+    # annotation - voxels
+    axis_index = ORIENTATION_TO_AXIS[orientation]
+    idx = int(POSITION[axis_index] / atlas_resolution)
+    mask_3d = atlas.get_structure_mask(region)
+    if axis_index == 0:  # frontal
+        mask_2d = mask_3d[idx, :, :] > 0
+    elif axis_index == 1:  # horizontal
+        mask_2d = mask_3d[:, idx, :] > 0
+    else:  # sagital
+        mask_2d = mask_3d[:, :, idx] > 0
+
+    rows, cols = np.where(mask_2d)
+
+    # voxel to µm
+    # sagittal x=rows, y=cols
+    if orientation == "sagittal":
+        ann_pts = np.column_stack(
+            [rows * atlas_resolution, cols * atlas_resolution]
+        )
+    else:
+        ann_pts = np.column_stack(
+            [cols * atlas_resolution, rows * atlas_resolution]
+        )
+
+    # for each mesh point, distance to nearest annotation
+    diffs = mesh_pts[:, None, :] - ann_pts[None, :, :]
+    distances = np.linalg.norm(diffs, axis=2).min(axis=1)
+
+    p95 = np.percentile(distances, 95)
+
+    assert p95 < THRESHOLD_UM, (
+        f"{orientation}/{region}: "
+        f"mesh contour points too far from annotation voxels. "
+        f"p95={p95:.0f} µm, threshold={THRESHOLD_UM} µm"
+    )
+
+
+# Expects that Tuple orientation (1,0,0) produce same coords as 'frontal', etc.
+@pytest.mark.parametrize("orientation", ["frontal", "horizontal", "sagittal"])
+@pytest.mark.parametrize("region", REGIONS)
+def test_tuple_orientation_matches_named(orientation, region):
+    ORIENTATION_TO_TUPLE = {
+        "frontal": (1, 0, 0),
+        "horizontal": (0, 1, 0),
+        "sagittal": (0, 0, 1),
+    }
+
+    tuple_coords = bgh.get_structures_slice_coords(
+        [region],
+        position=POSITION,
+        orientation=ORIENTATION_TO_TUPLE[orientation],
+    )
+
+    named_coords = bgh.get_structures_slice_coords(
+        [region], position=POSITION, orientation=orientation
+    )
+
+    tuple_pts = np.vstack(tuple_coords[region])
+    named_pts = np.vstack(named_coords[region])
+
+    # Points should be close (same contour, possibly different ordering)
+    diffs = tuple_pts[None, :, :] - named_pts[:, None, :]
+    distances = np.linalg.norm(diffs, axis=2).min(axis=1)
+    max_dist = distances.max()
+
+    assert max_dist < THRESHOLD_UM, (
+        f"{orientation}/{region}: named vs tuple coords differ. "
+        f"max_dist={max_dist:.0f} µm, threshold={THRESHOLD_UM} µm"
+    )

--- a/tests/test_integration/test_slicer_2d_example.py
+++ b/tests/test_integration/test_slicer_2d_example.py
@@ -1,0 +1,47 @@
+import runpy
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+EXAMPLE_SCRIPT = Path(__file__).parents[2] / "examples" / "slicer_2D.py"
+
+
+# expects ax.images and ax.patches to be drawn
+# expects ax.patches are drawn on ax.images
+def test_region_contours_overlap_brain_reference():
+    plt.close("all")
+    try:
+        runpy.run_path(str(EXAMPLE_SCRIPT))
+
+        ax = plt.gcf().axes[0]
+
+        assert len(ax.images) > 0, "No reference drawn"
+        assert len(ax.patches) > 0, "No contour polygons drawn"
+
+        left, right, bottom, top = ax.images[0].get_extent()
+        x_min, x_max = sorted([left, right])
+        y_min, y_max = sorted([bottom, top])
+
+        for patch in ax.patches:
+            verts = patch.get_path().vertices
+            assert (
+                verts[:, 0].min() >= x_min
+            ), (
+                "contour extends outside to left of image"
+            )  # type: ignore[index]
+            assert (
+                verts[:, 0].max() <= x_max
+            ), (
+                "contour extends outside to right of image"
+            )  # type: ignore[index]
+            assert (
+                verts[:, 1].min() >= y_min
+            ), "contour extends outside to below image"  # type: ignore[index]
+            assert (
+                verts[:, 1].max() <= y_max
+            ), "contour extends outside to above image"  # type: ignore[index]
+    finally:
+        plt.close("all")


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix

**Why is this PR needed?**

Related to 2D:
- Coordinates centered on the slice position instead of atlas space (#55)
- Coordinates centered on brain center of mass with named orientations
- Coordinates centered on plane center with tuple orientations
- Tuple orientations like (1, 0, 0) not matching named orientation "frontal"
- `slicer_2D.py` example contours not overlapping with reference (#72)
- `get_coordinates.py` example returning brain center of mass coordinates
  
**What does this PR do?**

This PR adds a separate projection step in the Slicer `_project_to_2d( )` that:
- Undoes the brainrender Z-flip on intersection points
- Projects to 2D with corrected atlas-space M
- Add example heatmap_2d_subplots_oblique.py

*New tests*:
**`test_get_coordinates.py`**
- Confirms mesh contour coords are within 75µm of atlas annotation
- tuple orientation (1,0,0) produces same coords as "frontal", etc.
- oblique orientations (0,1,1), (1,0,1), (0.3,0.7,1) produce spread on both 2D axes(Confirms that axis don't go flat due to Z)

**`test_slicer_2d_example.py`**
- runs the `slicer_2D.py` example end-to-end, verifies region contours are drawn on top of the brain image 

*New example*:
**`heatmap_2d_subplots_oblique.py`**

The `get_projections( )` method is preserved for anyone using plane centered coordinates and doc updated.
  
## References

- Fix #55 
- Fix #72 

## How has this PR been tested?

- New tests
- New example
- A custom `plan.py` example-like to confirm every plane0 projections on 3D match 2D new example images.

## Is this a breaking change?

Yes ✔
*Expectations of get_structures_slice_coords() changes*:
- Code that negated Y coordinates to compensate (like `slicer_2D.py` did with -cont[:, 1]) will need to remove that negation
- Coordinates are not centered with brain center of mass on named orientations[bug fix]
- Coordinates are not centered with plane center on tuple orientations[bug fix]

## Does this PR require an update to the documentation?

No

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
