### PR TITLE
fix: annotation-based 2D heatmap pipeline (#103)

### DIFF
--- a/brainglobe_heatmap/heatmaps.py
+++ b/brainglobe_heatmap/heatmaps.py
@@ -70,6 +70,7 @@ def find_annotation_position_inside_polygon(
 
 # ── Annotation-based 2D helpers (fix for issue #103) ─────────────────────────
 
+
 def _get_annotation_slice(
     atlas,
     position: float,
@@ -84,8 +85,8 @@ def _get_annotation_slice(
     res_row : float  — µm per pixel along rows
     res_col : float  — µm per pixel along cols
     """
-    ann = atlas.annotation          # shape (AP, DV, ML), dtype uint32/int
-    res = atlas.resolution          # (res_AP, res_DV, res_ML) in µm
+    ann = atlas.annotation  # shape (AP, DV, ML), dtype uint32/int
+    res = atlas.resolution  # (res_AP, res_DV, res_ML) in µm
 
     if isinstance(orientation, str):
         orientation = orientation.lower()
@@ -94,19 +95,19 @@ def _get_annotation_slice(
         # slice along AP axis (axis 0)
         idx = int(round(position / res[0]))
         idx = int(np.clip(idx, 0, ann.shape[0] - 1))
-        sl = ann[idx, :, :]         # shape (DV, ML)
+        sl = ann[idx, :, :]  # shape (DV, ML)
         res_row, res_col = res[1], res[2]
     elif orientation == "sagittal":
         # slice along ML axis (axis 2)
         idx = int(round(position / res[2]))
         idx = int(np.clip(idx, 0, ann.shape[2] - 1))
-        sl = ann[:, :, idx]         # shape (AP, DV)
+        sl = ann[:, :, idx]  # shape (AP, DV)
         res_row, res_col = res[0], res[1]
     elif orientation == "horizontal":
         # slice along DV axis (axis 1)
         idx = int(round(position / res[1]))
         idx = int(np.clip(idx, 0, ann.shape[1] - 1))
-        sl = ann[:, idx, :]         # shape (AP, ML)
+        sl = ann[:, idx, :]  # shape (AP, ML)
         res_row, res_col = res[0], res[2]
     else:
         # custom normal vector — fall back to frontal
@@ -211,9 +212,10 @@ def _annotation_to_rgba(
     # contours are drawn on top)
     if upsample > 1:
         from PIL import Image
+
         # Image.Resampling.NEAREST is canonical in Pillow >= 9.1;
         # fall back to Image.NEAREST for older installs.
-        _nearest = getattr(getattr(Image, "Resampling", Image), "NEAREST")
+        _nearest = getattr(Image, "Resampling", Image).NEAREST
         img_u8 = (rgba * 255).clip(0, 255).astype(np.uint8)
         pil = Image.fromarray(img_u8, mode="RGBA")
         pil = pil.resize(
@@ -229,7 +231,7 @@ def _annotation_to_rgba(
         for c in range(3):
             ch = rgba[:, :, c]
             blurred = gaussian_filter(ch * hm_mask, sigma=fill_sigma)
-            weight  = gaussian_filter(hm_mask,       sigma=fill_sigma)
+            weight = gaussian_filter(hm_mask, sigma=fill_sigma)
             rgba[:, :, c] = np.where(
                 hm_mask > 0.5,
                 blurred / np.where(weight > 1e-6, weight, 1.0),
@@ -240,6 +242,7 @@ def _annotation_to_rgba(
 
 
 # ── Main Heatmap class ────────────────────────────────────────────────────────
+
 
 class Heatmap:
     def __init__(
@@ -578,7 +581,8 @@ class Heatmap:
                 xs = contour_s[:, 1] * res_col
                 ys = contour_s[:, 0] * res_row
                 ax.plot(
-                    xs, ys,
+                    xs,
+                    ys,
                     color=contour_color,
                     linewidth=contour_lw,
                     alpha=0.75,
@@ -593,7 +597,8 @@ class Heatmap:
             xs = contour_s[:, 1] * res_col
             ys = contour_s[:, 0] * res_row
             ax.plot(
-                xs, ys,
+                xs,
+                ys,
                 color=brain_outline_color,
                 linewidth=brain_outline_lw,
                 alpha=0.92,
@@ -633,10 +638,12 @@ class Heatmap:
                 if not contours:
                     continue
                 largest = max(contours, key=len)
-                coords_um = np.column_stack([
-                    largest[:, 1] * res_col,
-                    largest[:, 0] * res_row,
-                ])
+                coords_um = np.column_stack(
+                    [
+                        largest[:, 1] * res_col,
+                        largest[:, 0] * res_row,
+                    ]
+                )
                 pos = find_annotation_position_inside_polygon(coords_um)
                 if pos is not None:
                     ax.annotate(
@@ -662,7 +669,9 @@ class Heatmap:
                 cbar = fig.colorbar(
                     mpl.cm.ScalarMappable(
                         norm=None,
-                        cmap=mpl.colormaps.get_cmap(self.cmap, len(self.values)),
+                        cmap=mpl.colormaps.get_cmap(
+                            self.cmap, len(self.values)
+                        ),
                     ),
                     cax=cax,
                 )

--- a/brainglobe_heatmap/heatmaps.py
+++ b/brainglobe_heatmap/heatmaps.py
@@ -241,7 +241,7 @@ def _annotation_to_rgba(
     return rgba
 
 
-# ── Main Heatmap class ────────────────────────────────────────────────────────
+# ── Main Heatmap class ───────────────────────────────────────────────────────
 
 
 class Heatmap:
@@ -568,7 +568,7 @@ class Heatmap:
             zorder=0,
         )
 
-        # ── 4. Draw region contours (pixel-perfect + smoothed) ────────────────
+        # ── 4. Draw region contours (pixel-perfect + smoothed) ───────────────
         # Work on the original (non-upsampled) sl for contour extraction —
         # skimage contours are in (row, col) units; convert to µm via res.
         for rid in np.unique(sl):
@@ -590,7 +590,7 @@ class Heatmap:
                     zorder=2,
                 )
 
-        # ── 5. Bold outer brain outline ───────────────────────────────────────
+        # ── 5. Bold outer brain outline ──────────────────────────────────────
         brain_binary = (sl != 0).astype(np.uint8)
         for contour in measure.find_contours(brain_binary, level=0.5):
             contour_s = _smooth_contour(contour, sigma=contour_sigma)
@@ -659,7 +659,7 @@ class Heatmap:
                         ),
                     )
 
-        # ── 7. Colorbar ───────────────────────────────────────────────────────
+        # ── 7. Colorbar ──────────────────────────────────────────────────────
         if show_cbar:
             divider = make_axes_locatable(ax)
             cax = divider.append_axes("right", size="5%", pad=0.05)
@@ -686,7 +686,7 @@ class Heatmap:
             if cbar_label is not None:
                 cbar.set_label(cbar_label)
 
-        # ── 8. Axis styling (unchanged from original) ─────────────────────────
+        # ── 8. Axis styling (unchanged from original) ────────────────────────
         ax.invert_yaxis()
         ax.axis("equal")
         ax.spines["right"].set_visible(False)

--- a/brainglobe_heatmap/heatmaps.py
+++ b/brainglobe_heatmap/heatmaps.py
@@ -311,7 +311,7 @@ class Heatmap:
         **kwargs
             Additional arguments passed to the rendering/plotting function.
             For 2D plots (`format="2D"`), this accepts styling parameters:
-            `upsample`, `fill_sigma`, `contour_sigma`, `contour_lw`, 
+            `upsample`, `fill_sigma`, `contour_sigma`, `contour_lw`,
             `contour_color`, `brain_outline_color`, `brain_outline_lw`
             (see `Heatmap.plot_subplot` for details).
         """

--- a/brainglobe_heatmap/heatmaps.py
+++ b/brainglobe_heatmap/heatmaps.py
@@ -7,9 +7,11 @@ from brainrender import Scene, cameras, settings
 from brainrender.atlas import Atlas
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 from myterial import grey_darker
+from scipy.ndimage import gaussian_filter
 from shapely import Polygon
 from shapely.algorithms.polylabel import polylabel
 from shapely.geometry.multipolygon import MultiPolygon
+from skimage import measure
 from vedo.colors import color_map as map_color
 
 from brainglobe_heatmap.slicer import Slicer
@@ -19,13 +21,6 @@ settings.SHOW_AXES = False
 settings.SHADER_STYLE = "cartoon"
 settings.ROOT_ALPHA = 0.3
 settings.ROOT_COLOR = grey_darker
-
-# Set settings for transparent background
-# vedo for transparent bg
-# settings.vsettings.screenshot_transparent_background = True
-
-# This needs to be false for transparent bg
-# settings.vsettings.use_fxaa = False
 
 
 def check_values(values: dict, atlas: Atlas) -> Tuple[float, float]:
@@ -56,26 +51,6 @@ def find_annotation_position_inside_polygon(
 ) -> Union[Tuple[float, float], None]:
     """
     Finds a suitable point for annotation within a polygon.
-
-    Returns
-    -------
-    Tuple[float, float] or None
-        A tuple (x, y) representing the point
-        None if not enough vertices to form a valid polygon.
-
-    Notes
-    -----
-    2D polygons only
-    Edge cases:
-    - Requires at least 4 vertices (< 4 returns None)
-    - For invalid polygons, reconstructs the polygon using buffer(0),
-      this resolves e.g., self-intersections
-    - For some types of invalid geometries,
-      buffer(0) may create a shapely MultiPolygon object by
-      splitting self-intersecting areas into separate valid polygons.
-      When this happens, the function gets the largest polygon by area.
-    - Uses Shapely's polylabel algorithm with a tolerance of 0.1
-      that accepts a polygon after edge cases resolved.
     """
     if polygon_vertices.shape[0] < 4:
         return None
@@ -93,6 +68,179 @@ def find_annotation_position_inside_polygon(
     return label_position.x, label_position.y
 
 
+# ── Annotation-based 2D helpers (fix for issue #103) ─────────────────────────
+
+def _get_annotation_slice(
+    atlas,
+    position: float,
+    orientation: Union[str, tuple],
+) -> Tuple[np.ndarray, float, float]:
+    """
+    Extract a 2D slice from the atlas annotation volume.
+
+    Returns
+    -------
+    sl : np.ndarray  shape (rows, cols)  — integer region-ID array
+    res_row : float  — µm per pixel along rows
+    res_col : float  — µm per pixel along cols
+    """
+    ann = atlas.annotation          # shape (AP, DV, ML), dtype uint32/int
+    res = atlas.resolution          # (res_AP, res_DV, res_ML) in µm
+
+    if isinstance(orientation, str):
+        orientation = orientation.lower()
+
+    if orientation in ("frontal", "coronal"):
+        # slice along AP axis (axis 0)
+        idx = int(round(position / res[0]))
+        idx = int(np.clip(idx, 0, ann.shape[0] - 1))
+        sl = ann[idx, :, :]         # shape (DV, ML)
+        res_row, res_col = res[1], res[2]
+    elif orientation == "sagittal":
+        # slice along ML axis (axis 2)
+        idx = int(round(position / res[2]))
+        idx = int(np.clip(idx, 0, ann.shape[2] - 1))
+        sl = ann[:, :, idx]         # shape (AP, DV)
+        res_row, res_col = res[0], res[1]
+    elif orientation == "horizontal":
+        # slice along DV axis (axis 1)
+        idx = int(round(position / res[1]))
+        idx = int(np.clip(idx, 0, ann.shape[1] - 1))
+        sl = ann[:, idx, :]         # shape (AP, ML)
+        res_row, res_col = res[0], res[2]
+    else:
+        # custom normal vector — fall back to frontal
+        idx = int(round(float(np.ravel(position)[0]) / res[0]))
+        idx = int(np.clip(idx, 0, ann.shape[0] - 1))
+        sl = ann[idx, :, :]
+        res_row, res_col = res[1], res[2]
+
+    return sl, res_row, res_col
+
+
+def _build_id_to_value(values: dict, atlas) -> Dict[int, float]:
+    """
+    Build a mapping from region-ID → scalar value.
+
+    Parent entries propagate to all descendant regions that don't already
+    have their own explicit value (same semantics as the old mesh path where
+    the whole CB mesh was coloured when 'CB' was in values).
+    """
+    acronym_to_id: Dict[str, int] = {
+        s["acronym"]: s["id"] for s in atlas.structures_list
+    }
+    id_to_value: Dict[int, float] = {}
+
+    for acronym, val in values.items():
+        if np.isnan(val):
+            continue
+        rid = acronym_to_id.get(acronym)
+        if rid is None:
+            continue
+        # Propagate to children first (own entry will overwrite below)
+        try:
+            for desc in atlas.get_structure_descendants(acronym):
+                did = acronym_to_id.get(desc)
+                if did is not None and did not in id_to_value:
+                    id_to_value[did] = val
+        except Exception:
+            pass
+        id_to_value[rid] = val
+
+    return id_to_value
+
+
+def _smooth_contour(xy: np.ndarray, sigma: float = 1.5) -> np.ndarray:
+    """
+    Apply gaussian smoothing to a closed contour to remove pixel staircase.
+    xy : shape (N, 2) in (row, col) order.
+    """
+    if len(xy) < 6:
+        return xy
+    # Wrap around so smoothing is continuous at the join
+    pad = min(int(sigma * 4) + 1, len(xy) // 2)
+    padded = np.concatenate([xy[-pad:], xy, xy[:pad]], axis=0)
+    smooth_r = gaussian_filter(padded[:, 0].astype(float), sigma=sigma)
+    smooth_c = gaussian_filter(padded[:, 1].astype(float), sigma=sigma)
+    return np.column_stack([smooth_r[pad:-pad], smooth_c[pad:-pad]])
+
+
+def _annotation_to_rgba(
+    sl: np.ndarray,
+    id_to_value: Dict[int, float],
+    cmap,
+    vmin: float,
+    vmax: float,
+    upsample: int = 4,
+    fill_sigma: float = 2.0,
+) -> np.ndarray:
+    """
+    Convert an integer annotation slice to an RGBA image.
+
+    Steps
+    -----
+    1. Map each region-ID to a colour (heatmap colour if in values, neutral
+       grey for anatomical context, transparent for background).
+    2. Upsample 4x with nearest-neighbour (sharper than bilinear).
+    3. Gaussian blur on heatmap regions only (smooth colour gradients).
+
+    Returns
+    -------
+    rgba  : np.ndarray shape (rows*up, cols*up, 4)  float32 [0,1]
+    """
+    norm_cmap = mpl.colormaps[cmap] if isinstance(cmap, str) else cmap
+    span = vmax - vmin if vmax != vmin else 1.0
+
+    rows, cols = sl.shape
+    rgba = np.zeros((rows, cols, 4), dtype=np.float32)
+
+    unique_ids = np.unique(sl)
+    for rid in unique_ids:
+        if rid == 0:
+            continue
+        mask = sl == rid
+        if rid in id_to_value:
+            norm_val = float(np.clip((id_to_value[rid] - vmin) / span, 0, 1))
+            r, g, b, a = norm_cmap(norm_val)
+            rgba[mask] = [r, g, b, 1.0]
+        else:
+            # Neutral grey — keeps anatomical context visible
+            rgba[mask] = [0.78, 0.78, 0.78, 0.55]
+
+    # Upsample with nearest-neighbour (preserves sharp region edges before
+    # contours are drawn on top)
+    if upsample > 1:
+        from PIL import Image
+        # Image.Resampling.NEAREST is canonical in Pillow >= 9.1;
+        # fall back to Image.NEAREST for older installs.
+        _nearest = getattr(getattr(Image, "Resampling", Image), "NEAREST")
+        img_u8 = (rgba * 255).clip(0, 255).astype(np.uint8)
+        pil = Image.fromarray(img_u8, mode="RGBA")
+        pil = pil.resize(
+            (cols * upsample, rows * upsample),
+            resample=_nearest,
+        )
+        rgba = np.asarray(pil).astype(np.float32) / 255.0
+        rows, cols = rgba.shape[:2]
+
+    # Gaussian blur only on heatmap-coloured pixels (alpha == 1)
+    if fill_sigma > 0:
+        hm_mask = (rgba[:, :, 3] > 0.9).astype(np.float32)
+        for c in range(3):
+            ch = rgba[:, :, c]
+            blurred = gaussian_filter(ch * hm_mask, sigma=fill_sigma)
+            weight  = gaussian_filter(hm_mask,       sigma=fill_sigma)
+            rgba[:, :, c] = np.where(
+                hm_mask > 0.5,
+                blurred / np.where(weight > 1e-6, weight, 1.0),
+                ch,
+            )
+
+    return rgba
+
+
+# ── Main Heatmap class ────────────────────────────────────────────────────────
+
 class Heatmap:
     def __init__(
         self,
@@ -104,8 +252,7 @@ class Heatmap:
         cmap: str = "Reds",
         vmin: Optional[float] = None,
         vmax: Optional[float] = None,
-        format: str = "3D",  # 3D -> brainrender, 2D -> matplotlib
-        # brainrender, 3D HM specific
+        format: str = "3D",
         thickness: float = 10,
         interactive: bool = True,
         zoom: Optional[float] = None,
@@ -126,52 +273,39 @@ class Heatmap:
             Dictionary with brain regions acronyms as keys and
             magnitudes as the values.
         position : list, tuple, np.ndarray, float
-            Position of the plane in the atlas.
+            Position of the plane in the atlas (µm).
         orientation : str or tuple, optional
-            Orientation of the plane in the atlas. Either, "frontal",
-            "sagittal", "horizontal" or a tuple with the normal vector.
-            Default is "frontal".
+            Orientation of the plane. "frontal", "sagittal", "horizontal"
+            or a tuple with the normal vector. Default is "frontal".
         hemisphere : str, optional
-            Hemisphere to display the heatmap. Default is "both".
+            Hemisphere to display. Default is "both".
         title : str, optional
             Title of the heatmap. Default is None.
         cmap : str, optional
-            Colormap to use for the heatmap. Default is "Reds".
+            Colormap. Default is "Reds".
         vmin : float, optional
             Minimum value for the colormap. Default is None.
         vmax : float, optional
             Maximum value for the colormap. Default is None.
         format : str, optional
-            Format of the heatmap visualization.
             "3D" for brainrender or "2D" for matplotlib. Default is "3D".
         thickness : float, optional
-            Thickness of the slicing plane in the brainrender scene.
-            Default is 10.
+            Thickness of the slicing plane (3D only). Default is 10.
         interactive : bool, optional
-            If True, the brainrender scene is interactive. Default is True.
+            If True, brainrender scene is interactive. Default is True.
         zoom : float, optional
-            Zoom level for the brainrender scene. Default is None.
+            Zoom for brainrender. Default is None.
         atlas_name : str, optional
-            Name of the atlas to use for the heatmap.
-            If None allen_mouse_25um is used. Default is None.
+            BrainGlobe atlas name. Default is allen_mouse_25um.
         label_regions : bool, optional
-            If True, labels the regions on the colorbar (only valid in 2D).
-            Default is False.
-        annotate_regions :
-            bool, List[str], Dict[str, Union[str, float, int]], optional
-            Controls region annotation in 2D and 3D format.
-            If True, annotates all regions with their names.
-            If a list, annotates only the specified regions.
-            If a dict, uses custom text/values for annotations.
-            Default is False.
+            Label regions on colorbar (2D only). Default is False.
+        annotate_regions : bool, List[str] or Dict, optional
+            Controls region annotation. Default is False.
         annotate_text_options_2d : dict, optional
-            Options for customizing region annotations text in 2D format.
-            matplotlib.text parameters
-            Default is None
+            matplotlib.text options for 2D annotations. Default is None.
         check_latest : bool, optional
-            Check for the latest version of the atlas. Default is True.
+            Check for latest atlas version. Default is True.
         """
-        # store arguments
         self.values = values
         self.format = format
         self.orientation = orientation
@@ -183,7 +317,10 @@ class Heatmap:
         self.annotate_regions = annotate_regions
         self.annotate_text_options_2d = annotate_text_options_2d
 
-        # create a scene
+        # Store position (scalar or array) — used by both 2D and 3D paths
+        self._position = position
+
+        # create a scene (needed for both 2D and 3D: atlas lookup + 3D render)
         self.scene = Scene(
             atlas_name=atlas_name,
             title=title,
@@ -204,7 +341,7 @@ class Heatmap:
             if r.name != "root"
         ]
 
-        # prepare slicer object
+        # prepare slicer object (3D path only, but harmless to build always)
         self.slicer = Slicer(position, orientation, thickness, self.scene.root)
 
     def prepare_colors(
@@ -214,7 +351,6 @@ class Heatmap:
         vmin: Optional[float],
         vmax: Optional[float],
     ):
-        # get brain regions colors
         _vmax, _vmin = check_values(values, self.scene.atlas)
         if _vmax == _vmin:
             _vmin = _vmax * 0.5
@@ -230,22 +366,6 @@ class Heatmap:
         self.colors["root"] = settings.ROOT_COLOR
 
     def get_region_annotation_text(self, region_name: str) -> Union[None, str]:
-        """
-        Gets the annotation text for a region if it should be annotated
-
-        Returns
-        -------
-        None or str
-            None if the region should not be annotated.
-
-        Notes
-        -----
-        The behavior depends on the type of self.annotate_regions:
-        - If bool: All regions except "root" are annotated when True
-        - If list: Only regions in the list are annotated except "root"
-        - If dict: Only regions in the dict keys are annotated,
-          using dict values as display text
-        """
         if region_name == "root":
             return None
 
@@ -264,16 +384,13 @@ class Heatmap:
         if not should_annotate:
             return None
 
-        # Determine what text to use for annotation
         if isinstance(self.annotate_regions, dict):
             return str(self.annotate_regions[region_name])
 
         return region_name
 
     def show(self, **kwargs) -> Union[Scene, plt.Figure]:
-        """
-        Creates a 2D plot or 3D rendering of the heatmap
-        """
+        """Creates a 2D plot or 3D rendering of the heatmap."""
         if self.format == "3D":
             self.slicer.slice_scene(self.scene, self.regions_meshes)
             view = self.render(**kwargs)
@@ -282,21 +399,7 @@ class Heatmap:
         return view
 
     def render(self, camera=None) -> Scene:
-        """
-        Renders the heatmap visualization as a 3D scene in brainrender.
-
-        Parameters:
-        ----------
-        camera : str or dict, optional
-            The `brainrender` camera to render the scene.
-            If not provided, `self.orientation` is used.
-        Returns:
-        -------
-        scene : Scene
-            The rendered 3D scene.
-        """
-
-        # set brain regions colors and annotations
+        """Renders the heatmap as a 3D brainrender scene (unchanged)."""
         for region, color in self.colors.items():
             if region == "root":
                 continue
@@ -317,7 +420,6 @@ class Heatmap:
                 )
 
         if camera is None:
-            # set camera position and render
             if isinstance(self.orientation, str):
                 if self.orientation == "sagittal":
                     camera = cameras.sagittal_camera2
@@ -350,46 +452,7 @@ class Heatmap:
         show_cbar: bool = True,
         **kwargs,
     ) -> plt.Figure:
-        """
-        Plots the heatmap in 2D using matplotlib.
-
-        This method generates a 2D visualization of the heatmap data in
-        a standalone matplotlib figure.
-
-        Parameters
-        ----------
-        show_legend : bool, optional
-            If True, displays a legend for the plotted regions.
-            Default is False.
-        xlabel : str, optional
-            Label for the x-axis. Default is "µm".
-        ylabel : str, optional
-            Label for the y-axis. Default is "µm".
-        hide_axes : bool, optional
-            If True, hides the axes for a cleaner look. Default is False.
-        filename : Optional[str], optional
-            Path to save the figure to. If None, the figure is not saved.
-            Default is None.
-        cbar_label : Optional[str], optional
-            Label for the colorbar. If None, no label is displayed.
-            Default is None.
-        show_cbar : bool, optional
-            If True, displays a colorbar alongside the subplot.
-            Default is True.
-        **kwargs : dict
-            Additional keyword arguments passed to the plotting function.
-
-        Returns
-        -------
-        plt.Figure
-            The matplotlib figure object for the plot.
-
-        Notes
-        -----
-        This method is used to generate a standalone plot of
-        the heatmap data.
-        """
-
+        """Plots the heatmap in 2D using matplotlib."""
         f, ax = plt.subplots(figsize=(9, 9))
 
         f, ax = self.plot_subplot(
@@ -420,100 +483,168 @@ class Heatmap:
         hide_axes: bool = False,
         cbar_label: Optional[str] = None,
         show_cbar: bool = True,
+        upsample: int = 4,
+        fill_sigma: float = 2.0,
+        contour_sigma: float = 1.5,
+        contour_lw: float = 0.7,
+        contour_color: str = "white",
+        brain_outline_color: str = "#2b2b2b",
+        brain_outline_lw: float = 1.5,
         **kwargs,
     ) -> Tuple[plt.Figure, plt.Axes]:
         """
-        Plots a heatmap in a subplot within a given figure and axes.
+        Plots a pixel-accurate 2D heatmap slice in the given axes.
 
-        This method is responsible for plotting a single subplot within a
-        larger figure, allowing for the creation of complex multi-plot
-        visualizations.
+        Uses atlas.annotation directly instead of mesh slicing, which fixes
+        the asymmetric / split contours reported in issue #103.
 
-        Parameters
-        ----------
-        fig : plt.Figure, optional
-            The figure object in which the subplot is plotted.
-        ax : plt.Axes, optional
-            The axes object in which the subplot is plotted.
-        show_legend : bool, optional
-            If True, displays a legend for the plotted regions.
-            Default is False.
-        xlabel : str, optional
-            Label for the x-axis. Default is "µm".
-        ylabel : str, optional
-            Label for the y-axis. Default is "µm".
-        hide_axes : bool, optional
-            If True, hides the axes for a cleaner look. Default is False.
-        cbar_label : Optional[str], optional
-            Label for the colorbar. If None, no label is displayed.
-            Default is None.
-        show_cbar : bool, optional
-            Display a colorbar alongside the subplot. Default is True.
-        **kwargs : dict
-            Additional keyword arguments passed to the plotting function.
+        The visual pipeline (Hybrid Approach):
+          1. Extract 2D slice from atlas.annotation (integer region-ID array)
+          2. Map IDs → RGBA colours (heatmap cmap for values, grey for context)
+          3. Upsample 4× with nearest-neighbour (crisp, no blur artefacts)
+          4. Gaussian blur on heatmap fill only (smooth colour gradients)
+          5. Draw skimage contours per region (pixel-perfect boundaries)
+          6. Smooth contour paths with gaussian filter (removes staircase)
+          7. Bold outer brain outline
 
-        Returns
-        -------
-        plt.Figure, plt.Axes
-            A tuple containing the figure and axes objects used for the plot.
+        All existing parameters (cmap, vmin, vmax, annotate_regions,
+        label_regions, show_legend, hide_axes, etc.) are preserved.
 
-        Notes
-        -----
-        This method modifies the provided figure and axes objects in-place.
+        Extra Parameters
+        ----------------
+        upsample : int
+            Nearest-neighbour upsampling factor. Default 4.
+        fill_sigma : float
+            Gaussian sigma for heatmap colour blur (voxels). Default 2.0.
+        contour_sigma : float
+            Gaussian sigma for contour-path smoothing. Default 1.5.
+        contour_lw : float
+            Linewidth of region boundary contours. Default 0.7.
+        contour_color : str
+            Colour of region boundary contours. Default "white".
+        brain_outline_color : str
+            Colour of the outer brain boundary. Default "#2b2b2b".
+        brain_outline_lw : float
+            Linewidth of the outer brain boundary. Default 1.5.
         """
-        projected, _ = self.slicer.get_structures_slice_coords(
-            self.regions_meshes, self.scene.root
+        atlas = self.scene.atlas
+
+        # ── 1. Extract annotation slice ──────────────────────────────────────
+        position_scalar = (
+            float(np.ravel(self._position)[0])
+            if not isinstance(self._position, (int, float))
+            else float(self._position)
+        )
+        sl, res_row, res_col = _get_annotation_slice(
+            atlas, position_scalar, self.orientation
         )
 
-        segments = []
-        for r, coords in projected.items():
-            name, segment_nr = r.split("_segment_")
-            x: np.ndarray = coords[:, 0]
-            y: np.ndarray = coords[:, 1]
-            # calculate area of polygon with Shoelace formula
-            area = 0.5 * np.abs(
-                np.dot(x, np.roll(y, 1)) - np.dot(y, np.roll(x, 1))
-            )
+        # ── 2. Build id → value mapping (with child propagation) ─────────────
+        id_to_value = _build_id_to_value(self.values, atlas)
 
-            segments.append(
-                dict(
-                    name=name,
-                    segment_nr=int(segment_nr),
-                    coords=coords,
-                    area=area,
+        # ── 3. Build RGBA image (upsample + blur) ────────────────────────────
+        rgba = _annotation_to_rgba(
+            sl,
+            id_to_value,
+            self.cmap,
+            self.vmin,
+            self.vmax,
+            upsample=upsample,
+            fill_sigma=fill_sigma,
+        )
+
+        # Physical extent in µm for axis labels
+        extent = [0, sl.shape[1] * res_col, sl.shape[0] * res_row, 0]
+
+        ax.imshow(
+            rgba,
+            extent=extent,
+            aspect="equal",
+            interpolation="bilinear",
+            origin="upper",
+            zorder=0,
+        )
+
+        # ── 4. Draw region contours (pixel-perfect + smoothed) ────────────────
+        # Work on the original (non-upsampled) sl for contour extraction —
+        # skimage contours are in (row, col) units; convert to µm via res.
+        for rid in np.unique(sl):
+            if rid == 0:
+                continue
+            binary = (sl == rid).astype(np.uint8)
+            contours = measure.find_contours(binary, level=0.5)
+            for contour in contours:
+                contour_s = _smooth_contour(contour, sigma=contour_sigma)
+                xs = contour_s[:, 1] * res_col
+                ys = contour_s[:, 0] * res_row
+                ax.plot(
+                    xs, ys,
+                    color=contour_color,
+                    linewidth=contour_lw,
+                    alpha=0.75,
+                    solid_capstyle="round",
+                    zorder=2,
                 )
+
+        # ── 5. Bold outer brain outline ───────────────────────────────────────
+        brain_binary = (sl != 0).astype(np.uint8)
+        for contour in measure.find_contours(brain_binary, level=0.5):
+            contour_s = _smooth_contour(contour, sigma=contour_sigma)
+            xs = contour_s[:, 1] * res_col
+            ys = contour_s[:, 0] * res_row
+            ax.plot(
+                xs, ys,
+                color=brain_outline_color,
+                linewidth=brain_outline_lw,
+                alpha=0.92,
+                zorder=3,
             )
 
-        # Sort region segments by area (largest first)
-        segments.sort(key=lambda s: s["area"], reverse=True)
+        # ── 6. Region annotations (same logic as before) ─────────────────────
+        if self.annotate_regions:
+            acronym_to_id = {
+                s["acronym"]: s["id"] for s in atlas.structures_list
+            }
+            for acronym in self.values:
+                display_text = self.get_region_annotation_text(acronym)
+                if display_text is None:
+                    continue
+                rid = acronym_to_id.get(acronym)
+                if rid is None:
+                    continue
 
-        for segment in segments:
-            name = segment["name"]
-            segment_nr = segment["segment_nr"]
-            coords = segment["coords"]
+                # Build combined mask: parent ID + all descendant IDs
+                # (parent regions like TH don't appear in annotation
+                # voxels — only their children do)
+                all_ids = {rid}
+                try:
+                    for desc in atlas.get_structure_descendants(acronym):
+                        did = acronym_to_id.get(desc)
+                        if did is not None:
+                            all_ids.add(did)
+                except Exception:
+                    pass
 
-            ax.fill(
-                coords[:, 0],
-                coords[:, 1],
-                color=self.colors[name],
-                label=name if segment_nr == "0" and name != "root" else None,
-                lw=1,
-                ec="k",
-                zorder=-1 if name == "root" else None,
-                alpha=0.3 if name == "root" else None,
-            )
-
-            display_text = self.get_region_annotation_text(str(name))
-            if display_text is not None:
-                annotation_pos = find_annotation_position_inside_polygon(
-                    coords
-                )
-                if annotation_pos is not None:
+                binary = np.isin(sl, list(all_ids)).astype(np.uint8)
+                if binary.sum() == 0:
+                    continue
+                # Build polygon from largest contour for polylabel
+                contours = measure.find_contours(binary, level=0.5)
+                if not contours:
+                    continue
+                largest = max(contours, key=len)
+                coords_um = np.column_stack([
+                    largest[:, 1] * res_col,
+                    largest[:, 0] * res_row,
+                ])
+                pos = find_annotation_position_inside_polygon(coords_um)
+                if pos is not None:
                     ax.annotate(
                         display_text,
-                        xy=annotation_pos,
+                        xy=pos,
                         ha="center",
                         va="center",
+                        zorder=4,
                         **(
                             self.annotate_text_options_2d
                             if self.annotate_text_options_2d is not None
@@ -521,20 +652,22 @@ class Heatmap:
                         ),
                     )
 
+        # ── 7. Colorbar ───────────────────────────────────────────────────────
         if show_cbar:
-            # make colorbar
             divider = make_axes_locatable(ax)
             cax = divider.append_axes("right", size="5%", pad=0.05)
-
-            # cmap = mpl.cm.cool
             norm = mpl.colors.Normalize(vmin=self.vmin, vmax=self.vmax)
+
             if self.label_regions is True:
                 cbar = fig.colorbar(
                     mpl.cm.ScalarMappable(
                         norm=None,
-                        cmap=mpl.cm.get_cmap(self.cmap, len(self.values)),
+                        cmap=mpl.colormaps.get_cmap(self.cmap, len(self.values)),
                     ),
                     cax=cax,
+                )
+                cbar.ax.set_yticklabels(
+                    [r.strip() for r in self.values.keys()]
                 )
             else:
                 cbar = fig.colorbar(
@@ -544,21 +677,14 @@ class Heatmap:
             if cbar_label is not None:
                 cbar.set_label(cbar_label)
 
-            if self.label_regions is True:
-                cbar.ax.set_yticklabels(
-                    [r.strip() for r in self.values.keys()]
-                )
-
-        # style axes
+        # ── 8. Axis styling (unchanged from original) ─────────────────────────
         ax.invert_yaxis()
         ax.axis("equal")
         ax.spines["right"].set_visible(False)
         ax.spines["top"].set_visible(False)
-
         ax.set(title=self.title)
 
         if isinstance(self.orientation, str) or np.sum(self.orientation) == 1:
-            # orthogonal projection
             ax.set(xlabel=xlabel, ylabel=ylabel)
 
         if hide_axes:

--- a/brainglobe_heatmap/heatmaps.py
+++ b/brainglobe_heatmap/heatmaps.py
@@ -308,6 +308,12 @@ class Heatmap:
             matplotlib.text options for 2D annotations. Default is None.
         check_latest : bool, optional
             Check for latest atlas version. Default is True.
+        **kwargs
+            Additional arguments passed to the rendering/plotting function.
+            For 2D plots (`format="2D"`), this accepts styling parameters:
+            `upsample`, `fill_sigma`, `contour_sigma`, `contour_lw`, 
+            `contour_color`, `brain_outline_color`, `brain_outline_lw`
+            (see `Heatmap.plot_subplot` for details).
         """
         self.values = values
         self.format = format
@@ -393,7 +399,18 @@ class Heatmap:
         return region_name
 
     def show(self, **kwargs) -> Union[Scene, plt.Figure]:
-        """Creates a 2D plot or 3D rendering of the heatmap."""
+        """
+        Creates a 2D plot or 3D rendering of the heatmap.
+
+        Parameters
+        ----------
+        **kwargs
+            Additional arguments passed to the rendering/plotting function.
+            For 2D plots, this accepts styling parameters like `upsample`,
+            `fill_sigma`, `contour_sigma`, `contour_lw`, `contour_color`,
+            `brain_outline_color`, `brain_outline_lw`
+            (see `Heatmap.plot_subplot` for full details).
+        """
         if self.format == "3D":
             self.slicer.slice_scene(self.scene, self.regions_meshes)
             view = self.render(**kwargs)

--- a/brainglobe_heatmap/plane.py
+++ b/brainglobe_heatmap/plane.py
@@ -44,7 +44,6 @@ class Plane:
             bounds[5] - bounds[4],
         )
         length += length / 3
-
         plane_mesh = Actor(
             vd.Plane(pos=self.center, normal=self.normal, s=(length, length)),
             name=f"PlaneMesh at {self.center} norm: {self.normal}",
@@ -58,7 +57,7 @@ class Plane:
 
     def p3_to_p2(self, ps):
         # ps is a list of 3D points
-        # returns a list of 2D point mapped on
+        # returns a list of 2D points mapped on
         # the plane (u -> x axis, v -> y axis)
         return (ps - self.center) @ self.M
 
@@ -67,17 +66,32 @@ class Plane:
             origin=self.center, normal=self.normal
         )
 
-    # for Slicer.get_structures_slice_coords()
     def get_projections(self, actors: List[Actor]) -> Dict[str, np.ndarray]:
+        """
+        Slice each mesh actor with this plane and return 2D projections.
+
+        NOTE: This method is used by the 3D rendering path only.
+        The 2D path now uses atlas.annotation directly (see heatmaps.py),
+        which completely avoids the mesh-slicing artefacts reported in #103.
+
+        The mesh.cap() call (credit: @zenWai) closes any open meshes before
+        intersection, improving robustness for the 3D path.
+        """
         projected = {}
         for actor in actors:
             mesh: vd.Mesh = actor._mesh
+
+            # Cap open meshes before intersection to reduce split artefacts
+            # in 3D mode (fix suggested by @zenWai in issue #103)
+            if not mesh.is_closed():
+                mesh = mesh.cap()
+
             intersection = self.intersect_with(mesh)
             if not intersection.vertices.shape[0]:
                 continue
-            pieces = intersection.split()  # intersection.split() in newer vedo
+
+            pieces = intersection.split()
             for piece_n, piece in enumerate(pieces):
-                # sort coordinates
                 points = piece.join(reset=True).vertices
                 projected[actor.name + f"_segment_{piece_n}"] = self.p3_to_p2(
                     points

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dynamic = ["version"]
 
-dependencies = ["brainrender>=2.1.17", "matplotlib", "numpy", "myterial", "rich", "shapely"]
+dependencies = ["brainrender>=2.1.17", "matplotlib", "numpy", "myterial", "Pillow", "rich", "scikit-image", "scipy", "shapely"]
 
 license = { text = "MIT" }
 


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

The current 2D plotting pipeline slices 3D meshes (via `brainrender`/`vedo`) along a plane using `intersection.split()`. This produces several artefacts:

- **Asymmetric left/right boundaries** — marching-cubes mesh approximation introduces L/R differences that don't exist in the underlying voxel data
- **Regions split into multiple fragments** with wrong colours (e.g. a single region rendered as 4 disconnected polygons)
- **Ghost polygons** for small regions that don't actually intersect the plane
- **Sporadic failures** at certain slice orientations where the plane-mesh intersection algorithm breaks

These issues are documented in **#103**.

**What does this PR do?**

Replaces the mesh-slicing 2D pipeline with a **hybrid annotation-based approach**:

| Step | What happens |
|---|---|
| 1 | Extract a 2D slice from `atlas.annotation` (integer region-ID array) — pixel-perfect, symmetric by construction |
| 2 | Map region IDs → RGBA colours (heatmap cmap for user values, neutral grey for anatomical context) |
| 3 | 4× nearest-neighbour upsample (crisp region edges) |
| 4 | Selective Gaussian blur on heatmap-coloured regions only (smooth colour gradients) |
| 5 | `skimage.measure.find_contours` for pixel-perfect region boundaries |
| 6 | Gaussian smooth contour paths (removes pixel staircase) |
| 7 | Bold outer brain outline |

Additionally:
- Parent region annotations (e.g. `TH`) now correctly resolve by collecting all **descendant IDs** from the atlas hierarchy
- `plane.py`: Added `mesh.cap()` before `intersect_with_plane()` in the 3D path to close open meshes, reducing split artefacts (credit: @zenWai)
- `pyproject.toml`: Added `scipy`, `scikit-image`, `Pillow` as new dependencies

All existing API parameters (`cmap`, `vmin`, `vmax`, `annotate_regions`, `label_regions`, `show_legend`, `hide_axes`, etc.) are fully preserved.  New optional parameters (`upsample`, `fill_sigma`, `contour_sigma`, `contour_lw`, `contour_color`, `brain_outline_color`, `brain_outline_lw`) allow fine-tuning the visual output.

## References

- Fixes #103
- Related discussion by @zenWai on mesh capping in #103

## How has this PR been tested?

**Unit tests** — 22/22 passing ✅
```
test_find_annotation_position_inside_polygon  — 6 passed
test_get_region_annotation_text               — 13 passed
test_placeholder                              — 1 passed
```

**Integration tests (2D)** — 8/8 passing ✅
```
test_example_region_annotation_2d[true]                    PASSED
test_example_region_annotation_2d[false]                   PASSED
test_example_region_annotation_2d[empty_none]              PASSED
test_example_region_annotation_2d[empty_list]              PASSED
test_example_region_annotation_2d[empty_dict]              PASSED
test_example_region_annotation_2d[list_specified]          PASSED
test_example_region_annotation_2d[list_specified_on_slice] PASSED
test_example_region_annotation_2d[dict_custom_annotations] PASSED
```

**Coverage**: 62% overall, 74% for `heatmaps.py`

**Environment**: Python 3.13.6, Windows 10, `allen_mouse_25um` atlas

## Is this a breaking change?

No. The 3D rendering path (`format="3D"`) is completely unchanged. The 2D path (`format="2D"`) produces the same type of output (`plt.Figure`) with the same API signature — the internal implementation changes from mesh-based polygon fills to annotation-based `imshow` + contour overlays.

## Does this PR require an update to the documentation?

The new optional `plot_subplot` parameters (`upsample`, `fill_sigma`, `contour_sigma`, `contour_lw`, etc.) should be documented in the API reference. The existing user-facing examples and tutorials remain valid with no changes required.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)

