### PR TITLE
feat: allow different values per hemisphere (closes #58)

### DIFF
--- a/brainglobe_heatmap/heatmaps.py
+++ b/brainglobe_heatmap/heatmaps.py
@@ -4,7 +4,6 @@ import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 from brainrender import Scene, cameras, settings
-from brainrender.atlas import Atlas
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 from myterial import grey_darker
 from shapely import Polygon
@@ -14,81 +13,94 @@ from vedo.colors import color_map as map_color
 
 from brainglobe_heatmap.slicer import Slicer
 
-# Set settings for heatmap visualization
 settings.SHOW_AXES = False
 settings.SHADER_STYLE = "cartoon"
 settings.ROOT_ALPHA = 0.3
 settings.ROOT_COLOR = grey_darker
 
-# Set settings for transparent background
-# vedo for transparent bg
-# settings.vsettings.screenshot_transparent_background = True
 
-# This needs to be false for transparent bg
-# settings.vsettings.use_fxaa = False
-
-
-def check_values(values: dict, atlas: Atlas) -> Tuple[float, float]:
+def parse_values(values: Dict) -> Tuple[Dict, Dict]:
     """
-    Checks that the passed heatmap values meet two criteria:
-        - keys should be acronyms of brainregions
-        - values should be numbers
+    Splits values dict into bilateral (scalar) and per_hemisphere (dict) parts.
+
+    Parameters
+    ----------
+    values : dict
+        Keys are region acronyms. Values are either:
+        - float/int: same value for both hemispheres
+        - dict with "left" and/or "right" keys: hemisphere-specific values
+
+    Returns
+    -------
+    bilateral : dict
+    per_hemisphere : dict
     """
-    for k, v in values.items():
-        if not isinstance(v, (float, int)):
+    bilateral = {}
+    per_hemisphere = {}
+    for region, val in values.items():
+        if "__" in region:
             raise ValueError(
-                f"Heatmap values should be floats, "
-                f'not: {type(v)} for entry "{k}"'
+                f'Region name "{region}" contains "__" which is reserved '
+                f"for internal hemisphere tracking."
             )
+        if isinstance(val, dict):
+            if not val.keys() <= {"left", "right"}:
+                raise ValueError(
+                    f'Per-hemisphere dict for "{region}" may only contain '
+                    f'"left" and/or "right" keys, got: {list(val.keys())}'
+                )
+            if not val:
+                raise ValueError(
+                    f'Per-hemisphere dict for "{region}" is empty.'
+                )
+            per_hemisphere[region] = val
+        else:
+            bilateral[region] = val
+    return bilateral, per_hemisphere
 
+
+def check_values(values: Dict, atlas) -> Tuple[float, float]:
+    """
+    Validates region names and value types.
+    Returns global (vmax, vmin) across all values.
+    """
+    all_scalars = []
+    for k, v in values.items():
         if k not in atlas.lookup_df.acronym.values:
             raise ValueError(f'Region name "{k}" not recognized')
-
-    not_nan = [v for v in values.values() if not np.isnan(v)]
+        if isinstance(v, dict):
+            for side, sv in v.items():
+                if not isinstance(sv, (float, int)):
+                    raise ValueError(
+                        f"Heatmap values should be floats, "
+                        f'not: {type(sv)} for entry "{k}[{side}]"'
+                    )
+                all_scalars.append(sv)
+        else:
+            if not isinstance(v, (float, int)):
+                raise ValueError(
+                    f"Heatmap values should be floats, "
+                    f'not: {type(v)} for entry "{k}"'
+                )
+            all_scalars.append(v)
+    not_nan = [v for v in all_scalars if not np.isnan(v)]
     if len(not_nan) == 0:
         return np.nan, np.nan
-    vmax, vmin = max(not_nan), min(not_nan)
-    return vmax, vmin
+    return max(not_nan), min(not_nan)
 
 
 def find_annotation_position_inside_polygon(
     polygon_vertices: np.ndarray,
 ) -> Union[Tuple[float, float], None]:
-    """
-    Finds a suitable point for annotation within a polygon.
-
-    Returns
-    -------
-    Tuple[float, float] or None
-        A tuple (x, y) representing the point
-        None if not enough vertices to form a valid polygon.
-
-    Notes
-    -----
-    2D polygons only
-    Edge cases:
-    - Requires at least 4 vertices (< 4 returns None)
-    - For invalid polygons, reconstructs the polygon using buffer(0),
-      this resolves e.g., self-intersections
-    - For some types of invalid geometries,
-      buffer(0) may create a shapely MultiPolygon object by
-      splitting self-intersecting areas into separate valid polygons.
-      When this happens, the function gets the largest polygon by area.
-    - Uses Shapely's polylabel algorithm with a tolerance of 0.1
-      that accepts a polygon after edge cases are resolved.
-    """
     if polygon_vertices.shape[0] < 4:
         return None
     polygon = Polygon(polygon_vertices.tolist())
-
     if not polygon.is_valid:
         polygon = polygon.buffer(0)
-
     if polygon.geom_type == "MultiPolygon" and isinstance(
         polygon, MultiPolygon
     ):
         polygon = max(polygon.geoms, key=lambda p: p.area)
-
     label_position = polylabel(polygon, tolerance=0.1)
     return label_position.x, label_position.y
 
@@ -104,8 +116,7 @@ class Heatmap:
         cmap: str = "Reds",
         vmin: Optional[float] = None,
         vmax: Optional[float] = None,
-        format: str = "3D",  # 3D -> brainrender, 2D -> matplotlib
-        # brainrender, 3D HM specific
+        format: str = "3D",
         thickness: float = 10,
         interactive: bool = True,
         zoom: Optional[float] = None,
@@ -117,61 +128,40 @@ class Heatmap:
         **kwargs,
     ):
         """
-        Creates a heatmap visualization of the provided values in 3D or 2D
-        using brainrender or matplotlib in the specified atlas.
+        Creates a heatmap visualization of the provided values in 3D or 2D.
 
         Parameters
         ----------
         values : dict
-            Dictionary with brain regions acronyms as keys and
-            magnitudes as the values.
-        position : list, tuple, np.ndarray, float
-            Position of the plane in the atlas.
+            Keys are region acronyms. Values can be:
+            - float/int: same color for both hemispheres (backwards compatible)
+            - dict with "left"/"right" keys for hemisphere-specific colors
+
+            Example::
+
+                {
+                    "TH": 1.0,
+                    "VISp": {"left": 0.8, "right": 0.2},
+                    "MOp": {"left": 0.5},
+                }
+
+        position : list, tuple, np.ndarray, or float
         orientation : str or tuple, optional
-            Orientation of the plane in the atlas. Either, "frontal",
-            "sagittal", "horizontal" or a tuple with the normal vector.
-            Default is "frontal".
         hemisphere : str, optional
-            Hemisphere to display the heatmap. Default is "both".
+            Applies only to bilateral (scalar) regions. Default "both".
         title : str, optional
-            Title of the heatmap. Default is None.
         cmap : str, optional
-            Colormap to use for the heatmap. Default is "Reds".
-        vmin : float, optional
-            Minimum value for the colormap. Default is None.
-        vmax : float, optional
-            Maximum value for the colormap. Default is None.
-        format : str, optional
-            Format of the heatmap visualization.
-            "3D" for brainrender or "2D" for matplotlib. Default is "3D".
+        vmin, vmax : float, optional
+        format : str, optional. "3D" or "2D"
         thickness : float, optional
-            Thickness of the slicing plane in the brainrender scene.
-            Default is 10.
         interactive : bool, optional
-            If True, the brainrender scene is interactive. Default is True.
         zoom : float, optional
-            Zoom level for the brainrender scene. Default is None.
         atlas_name : str, optional
-            Name of the atlas to use for the heatmap.
-            If None allen_mouse_25um is used. Default is None.
         label_regions : bool, optional
-            If True, labels the regions on the colorbar (only valid in 2D).
-            Default is False.
-        annotate_regions :
-            bool, List[str], Dict[str, Union[str, float, int]], optional
-            Controls region annotation in 2D and 3D format.
-            If True, annotates all regions with their names.
-            If a list, annotates only the specified regions.
-            If a dict, uses custom text/values for annotations.
-            Default is False.
+        annotate_regions : bool, list, or dict, optional
         annotate_text_options_2d : dict, optional
-            Options for customizing region annotations text in 2D format.
-            matplotlib.text parameters
-            Default is None
         check_latest : bool, optional
-            Check for the latest version of the atlas. Default is True.
         """
-        # store arguments
         self.values = values
         self.format = format
         self.orientation = orientation
@@ -183,7 +173,8 @@ class Heatmap:
         self.annotate_regions = annotate_regions
         self.annotate_text_options_2d = annotate_text_options_2d
 
-        # create a scene
+        bilateral_values, per_hemisphere_values = parse_values(values)
+
         self.scene = Scene(
             atlas_name=atlas_name,
             title=title,
@@ -192,11 +183,24 @@ class Heatmap:
             **kwargs,
         )
 
-        # prep colors range
         self.prepare_colors(values, cmap, vmin, vmax)
 
-        # add regions to the brainrender scene
-        self.scene.add_brain_region(*self.values.keys(), hemisphere=hemisphere)
+        # Add bilateral regions using brainrender's hemisphere= param directly.
+        # Requires brainrender>=2.1.18 where get_plane() is numpy>=2.0
+        # compatible.
+        if bilateral_values:
+            self.scene.add_brain_region(
+                *bilateral_values.keys(), hemisphere=hemisphere
+            )
+
+        # Add per-hemisphere regions: one actor per requested side.
+        # force=True is required to get two separate actor instances for the
+        # same region (brainrender deduplicates by name otherwise).
+        for region, side_vals in per_hemisphere_values.items():
+            for side in side_vals:
+                self.scene.add_brain_region(
+                    region, hemisphere=side, force=True
+                )
 
         self.regions_meshes = [
             r
@@ -204,51 +208,98 @@ class Heatmap:
             if r.name != "root"
         ]
 
-        # prepare slicer object
+        # Rename per-hemisphere actors to REGION__side so the slicer produces
+        # unique segment keys (two actors with the same name would overwrite
+        # each other in the projected dict).
+        self._rename_hemisphere_actors(per_hemisphere_values)
+
+        # Map each actor -> color
+        self._build_actor_color_map()
+
         self.slicer = Slicer(position, orientation, thickness, self.scene.root)
+
+    def _rename_hemisphere_actors(self, per_hemisphere_values: Dict) -> None:
+        """
+        Renames per-hemisphere actors from "REGION" to "REGION__side" so the
+        slicer produces unique segment keys for each hemisphere.
+
+        brainrender's add_brain_region(hemisphere=) already cuts the mesh to
+        the correct side; we only need to rename here. Actors are matched to
+        sides in dict insertion order (left before right if both specified),
+        which mirrors the order they were added in __init__.
+        """
+        if not per_hemisphere_values:
+            return
+        seen: Dict[str, int] = {}
+        for actor in self.regions_meshes:
+            name = actor.name
+            if name not in per_hemisphere_values:
+                continue
+            requested_sides = list(per_hemisphere_values[name].keys())
+            seen[name] = seen.get(name, 0)
+            side = requested_sides[seen[name]]
+            seen[name] += 1
+            actor.name = f"{name}__{side}"
+
+    def _build_actor_color_map(self) -> None:
+        """
+        Builds self.actor_colors: {actor -> color}.
+
+        Per-hemisphere actors are named "REGION__side" after splitting.
+        The side is parsed directly from the name — no CoM detection needed.
+        Bilateral actors keep their plain region name.
+        """
+        self.actor_colors = {}
+        for actor in self.regions_meshes:
+            name = actor.name
+            if name == "root":
+                continue
+            if "__" in name:
+                region, side = name.rsplit("__", 1)
+                self.actor_colors[actor] = self.colors.get(
+                    f"{side}:{region}", settings.ROOT_COLOR
+                )
+            else:
+                self.actor_colors[actor] = self.colors.get(
+                    name, settings.ROOT_COLOR
+                )
 
     def prepare_colors(
         self,
-        values: dict,
+        values: Dict,
         cmap: str,
         vmin: Optional[float],
         vmax: Optional[float],
-    ):
-        # get brain regions colors
+    ) -> None:
+        """
+        Builds self.colors flat dict:
+        - "REGION" -> color  (bilateral)
+        - "left:REGION" / "right:REGION" -> color  (per-hemisphere)
+        - "root" -> ROOT_COLOR
+        """
         _vmax, _vmin = check_values(values, self.scene.atlas)
         if _vmax == _vmin:
             _vmin = _vmax * 0.5
-
         vmin = vmin if vmin == 0 or vmin else _vmin
         vmax = vmax if vmax == 0 or vmax else _vmax
         self.vmin, self.vmax = vmin, vmax
 
-        self.colors = {
-            r: list(map_color(v, name=cmap, vmin=vmin, vmax=vmax))
-            for r, v in values.items()
-        }
+        self.colors = {}
+        for region, val in values.items():
+            if isinstance(val, dict):
+                for side, sv in val.items():
+                    self.colors[f"{side}:{region}"] = list(
+                        map_color(sv, name=cmap, vmin=vmin, vmax=vmax)
+                    )
+            else:
+                self.colors[region] = list(
+                    map_color(val, name=cmap, vmin=vmin, vmax=vmax)
+                )
         self.colors["root"] = settings.ROOT_COLOR
 
     def get_region_annotation_text(self, region_name: str) -> Union[None, str]:
-        """
-        Gets the annotation text for a region if it should be annotated
-
-        Returns
-        -------
-        None or str
-            None if the region should not be annotated.
-
-        Notes
-        -----
-        The behavior depends on the type of self.annotate_regions:
-        - If bool: All regions except "root" are annotated when True
-        - If list: Only regions in the list are annotated except "root"
-        - If dict: Only regions in the dict keys are annotated,
-          using dict values as display text
-        """
         if region_name == "root":
             return None
-
         should_annotate = (
             (isinstance(self.annotate_regions, bool) and self.annotate_regions)
             or (
@@ -260,20 +311,13 @@ class Heatmap:
                 and region_name in self.annotate_regions.keys()
             )
         )
-
         if not should_annotate:
             return None
-
-        # Determine what text to use for annotation
         if isinstance(self.annotate_regions, dict):
             return str(self.annotate_regions[region_name])
-
         return region_name
 
-    def show(self, **kwargs) -> Union[Scene, plt.Figure]:
-        """
-        Creates a 2D plot or 3D rendering of the heatmap
-        """
+    def show(self, **kwargs) -> Union[Scene, "plt.Figure"]:
         if self.format == "3D":
             self.slicer.slice_scene(self.scene, self.regions_meshes)
             view = self.render(**kwargs)
@@ -282,42 +326,17 @@ class Heatmap:
         return view
 
     def render(self, camera=None) -> Scene:
-        """
-        Renders the heatmap visualization as a 3D scene in brainrender.
-
-        Parameters:
-        ----------
-        camera : str or dict, optional
-            The `brainrender` camera to render the scene.
-            If not provided, `self.orientation` is used.
-        Returns:
-        -------
-        scene : Scene
-            The rendered 3D scene.
-        """
-
-        # set brain regions colors and annotations
-        for region, color in self.colors.items():
-            if region == "root":
-                continue
-            region_actor = self.scene.get_actors(
-                br_class="brain region", name=region
-            )[0]
-            region_actor.color(color)
-
-            display_text = self.get_region_annotation_text(region_actor.name)
-
-            if (
-                len(region_actor._mesh.vertices) > 0
-                and display_text is not None
-            ):
-                self.scene.add_label(
-                    actor=region_actor,
-                    label=display_text,
-                )
+        for actor, color in self.actor_colors.items():
+            actor.color(color)
+            # Strip __side suffix for annotation lookup
+            display_name = (
+                actor.name.split("__")[0] if "__" in actor.name else actor.name
+            )
+            display_text = self.get_region_annotation_text(display_name)
+            if len(actor._mesh.vertices) > 0 and display_text is not None:
+                self.scene.add_label(actor=actor, label=display_text)
 
         if camera is None:
-            # set camera position and render
             if isinstance(self.orientation, str):
                 if self.orientation == "sagittal":
                     camera = cameras.sagittal_camera2
@@ -333,7 +352,6 @@ class Heatmap:
                     "viewup": (0, -1, 0),
                     "clipping_range": (19531, 40903),
                 }
-
         self.scene.render(
             camera=camera, interactive=self.interactive, zoom=self.zoom
         )
@@ -350,48 +368,7 @@ class Heatmap:
         show_cbar: bool = True,
         **kwargs,
     ) -> plt.Figure:
-        """
-        Plots the heatmap in 2D using matplotlib.
-
-        This method generates a 2D visualization of the heatmap data in
-        a standalone matplotlib figure.
-
-        Parameters
-        ----------
-        show_legend : bool, optional
-            If True, displays a legend for the plotted regions.
-            Default is False.
-        xlabel : str, optional
-            Label for the x-axis. Default is "µm".
-        ylabel : str, optional
-            Label for the y-axis. Default is "µm".
-        hide_axes : bool, optional
-            If True, hides the axes for a cleaner look. Default is False.
-        filename : Optional[str], optional
-            Path to save the figure to. If None, the figure is not saved.
-            Default is None.
-        cbar_label : Optional[str], optional
-            Label for the colorbar. If None, no label is displayed.
-            Default is None.
-        show_cbar : bool, optional
-            If True, displays a colorbar alongside the subplot.
-            Default is True.
-        **kwargs : dict
-            Additional keyword arguments passed to the plotting function.
-
-        Returns
-        -------
-        plt.Figure
-            The matplotlib figure object for the plot.
-
-        Notes
-        -----
-        This method is used to generate a standalone plot of
-        the heatmap data.
-        """
-
         f, ax = plt.subplots(figsize=(9, 9))
-
         f, ax = self.plot_subplot(
             fig=f,
             ax=ax,
@@ -403,10 +380,8 @@ class Heatmap:
             show_cbar=show_cbar,
             **kwargs,
         )
-
         if filename is not None:
             plt.savefig(filename, dpi=300)
-
         plt.show()
         return f
 
@@ -422,59 +397,23 @@ class Heatmap:
         show_cbar: bool = True,
         **kwargs,
     ) -> Tuple[plt.Figure, plt.Axes]:
-        """
-        Plots a heatmap in a subplot within a given figure and axes.
-
-        This method is responsible for plotting a single subplot within a
-        larger figure, allowing for the creation of complex multi-plot
-        visualizations.
-
-        Parameters
-        ----------
-        fig : plt.Figure, optional
-            The figure object in which the subplot is plotted.
-        ax : plt.Axes, optional
-            The axes object in which the subplot is plotted.
-        show_legend : bool, optional
-            If True, displays a legend for the plotted regions.
-            Default is False.
-        xlabel : str, optional
-            Label for the x-axis. Default is "µm".
-        ylabel : str, optional
-            Label for the y-axis. Default is "µm".
-        hide_axes : bool, optional
-            If True, hides the axes for a cleaner look. Default is False.
-        cbar_label : Optional[str], optional
-            Label for the colorbar. If None, no label is displayed.
-            Default is None.
-        show_cbar : bool, optional
-            Display a colorbar alongside the subplot. Default is True.
-        **kwargs : dict
-            Additional keyword arguments passed to the plotting function.
-
-        Returns
-        -------
-        plt.Figure, plt.Axes
-            A tuple containing the figure and axes objects used for the plot.
-
-        Notes
-        -----
-        This method modifies the provided figure and axes objects in-place.
-        """
         projected, _ = self.slicer.get_structures_slice_coords(
             self.regions_meshes, self.scene.root
         )
 
+        # actor_name_to_color maps full actor name (incl. __side suffix)
+        # to color
+        actor_name_to_color = {
+            actor.name: color for actor, color in self.actor_colors.items()
+        }
+
         segments = []
         for r, coords in projected.items():
             name, segment_nr = r.split("_segment_")
-            x: np.ndarray = coords[:, 0]
-            y: np.ndarray = coords[:, 1]
-            # calculate area of polygon with Shoelace formula
+            x, y = coords[:, 0], coords[:, 1]
             area = 0.5 * np.abs(
                 np.dot(x, np.roll(y, 1)) - np.dot(y, np.roll(x, 1))
             )
-
             segments.append(
                 dict(
                     name=name,
@@ -484,26 +423,30 @@ class Heatmap:
                 )
             )
 
-        # Sort region segments by area (largest first)
         segments.sort(key=lambda s: s["area"], reverse=True)
 
         for segment in segments:
             name = segment["name"]
             segment_nr = segment["segment_nr"]
             coords = segment["coords"]
-
+            color = actor_name_to_color.get(name, self.colors.get(name))
+            # Strip __side suffix for display purposes
+            display_name = name.split("__")[0] if "__" in name else name
             ax.fill(
                 coords[:, 0],
                 coords[:, 1],
-                color=self.colors[name],
-                label=name if segment_nr == "0" and name != "root" else None,
+                color=color,
+                label=(
+                    display_name
+                    if segment_nr == 0 and display_name != "root"
+                    else None
+                ),
                 lw=1,
                 ec="k",
                 zorder=-1 if name == "root" else None,
                 alpha=0.3 if name == "root" else None,
             )
-
-            display_text = self.get_region_annotation_text(str(name))
+            display_text = self.get_region_annotation_text(display_name)
             if display_text is not None:
                 annotation_pos = find_annotation_position_inside_polygon(
                     coords
@@ -522,17 +465,19 @@ class Heatmap:
                     )
 
         if show_cbar:
-            # make colorbar
             divider = make_axes_locatable(ax)
             cax = divider.append_axes("right", size="5%", pad=0.05)
-
-            # cmap = mpl.cm.cool
             norm = mpl.colors.Normalize(vmin=self.vmin, vmax=self.vmax)
+            # region_color_keys: all color entries except "root",
+            # in insertion order. For per-hemisphere values these include
+            # "left:REGION" and "right:REGION" as separate entries.
+            region_color_keys = [k for k in self.colors.keys() if k != "root"]
             if self.label_regions is True:
+                n = len(region_color_keys)
                 cbar = fig.colorbar(
                     mpl.cm.ScalarMappable(
                         norm=None,
-                        cmap=mpl.cm.get_cmap(self.cmap, len(self.values)),
+                        cmap=mpl.colormaps[self.cmap].resampled(n),
                     ),
                     cax=cax,
                 )
@@ -540,35 +485,27 @@ class Heatmap:
                 cbar = fig.colorbar(
                     mpl.cm.ScalarMappable(norm=norm, cmap=self.cmap), cax=cax
                 )
-
             if cbar_label is not None:
                 cbar.set_label(cbar_label)
-
             if self.label_regions is True:
-                cbar.ax.set_yticklabels(
-                    [r.strip() for r in self.values.keys()]
-                )
+                n = len(region_color_keys)
+                tick_locs = [(i + 0.5) / n for i in range(n)]
+                cbar.ax.yaxis.set_ticks(tick_locs)
+                cbar.ax.set_yticklabels([r.strip() for r in region_color_keys])
 
-        # style axes
         ax.invert_yaxis()
         ax.axis("equal")
         ax.spines["right"].set_visible(False)
         ax.spines["top"].set_visible(False)
-
         ax.set(title=self.title)
-
         if isinstance(self.orientation, str) or np.sum(self.orientation) == 1:
-            # orthogonal projection
             ax.set(xlabel=xlabel, ylabel=ylabel)
-
         if hide_axes:
             ax.spines["left"].set_visible(False)
             ax.spines["bottom"].set_visible(False)
             ax.set_xticks([])
             ax.set_yticks([])
             ax.set(xlabel="", ylabel="")
-
         if show_legend:
             ax.legend()
-
         return fig, ax

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dynamic = ["version"]
 
-dependencies = ["brainrender>=2.1.19", "matplotlib", "numpy", "myterial", "rich", "shapely"]
+dependencies = ["brainrender>=2.1.18", "matplotlib", "numpy", "myterial", "rich", "shapely"]
 
 license = { text = "MIT" }
 

--- a/tests/test_integration/test_hemisphere_specific_values.py
+++ b/tests/test_integration/test_hemisphere_specific_values.py
@@ -1,0 +1,410 @@
+"""
+Integration tests for hemisphere-specific heatmap values (issue #58).
+
+Users can now pass a dict with "left"/"right" keys for any region
+to visualise different values in each hemisphere.
+"""
+
+import matplotlib as mpl
+import pytest
+from brainrender import settings
+
+import brainglobe_heatmap as bgh
+
+settings.INTERACTIVE = False
+settings.OFFSCREEN = True
+mpl.use("Agg")
+
+
+@pytest.fixture
+def heatmap_both_hemispheres():
+    h = bgh.Heatmap(
+        values={"TH": {"left": 0.8, "right": 0.2}},
+        position=7000,
+        orientation="frontal",
+        format="2D",
+        check_latest=False,
+    )
+    yield h
+    h.scene.close()
+
+
+@pytest.fixture
+def heatmap_left_only():
+    h = bgh.Heatmap(
+        values={"TH": {"left": 0.5}},
+        position=7000,
+        orientation="frontal",
+        format="2D",
+        check_latest=False,
+    )
+    yield h
+    h.scene.close()
+
+
+@pytest.fixture
+def heatmap_mixed():
+    h = bgh.Heatmap(
+        values={
+            "TH": 1.0,
+            "VISp": {"left": 0.8, "right": 0.2},
+        },
+        position=7000,
+        orientation="frontal",
+        format="2D",
+        check_latest=False,
+    )
+    yield h
+    h.scene.close()
+
+
+def test_both_hemispheres_produces_two_actors(heatmap_both_hemispheres):
+    """Two actors should be created, one per hemisphere."""
+    th_actors = [
+        a for a in heatmap_both_hemispheres.regions_meshes if "TH" in a.name
+    ]
+    assert len(th_actors) == 2
+    names = {a.name for a in th_actors}
+    assert names == {"TH__left", "TH__right"}
+
+
+def test_both_hemispheres_different_colors(heatmap_both_hemispheres):
+    """Left and right actors should have different colors."""
+    color_by_name = {
+        a.name: c for a, c in heatmap_both_hemispheres.actor_colors.items()
+    }
+    assert color_by_name["TH__left"] != color_by_name["TH__right"]
+    # In Reds cmap the R channel is NOT monotonic with value —
+    # darker reds (high value) have lower R.
+    # left=0.8 -> R=0.40, right=0.2 -> R=1.0
+    assert color_by_name["TH__left"][0] < color_by_name["TH__right"][0]
+
+
+def test_left_only_produces_one_actor(heatmap_left_only):
+    """Only one actor should be created when only left is specified."""
+    th_actors = [a for a in heatmap_left_only.regions_meshes if "TH" in a.name]
+    assert len(th_actors) == 1
+    assert th_actors[0].name == "TH__left"
+
+
+def test_mixed_bilateral_and_per_hemisphere(heatmap_mixed):
+    """Bilateral regions keep plain names; per-hemisphere get __side suffix."""
+    names = {a.name for a in heatmap_mixed.regions_meshes}
+    assert "TH" in names
+    assert "VISp__left" in names
+    assert "VISp__right" in names
+    assert "TH__left" not in names
+    assert "TH__right" not in names
+
+
+def test_vmin_vmax_spans_all_values(heatmap_mixed):
+    """vmin/vmax should be computed across bilateral and per-hemisphere."""
+    assert heatmap_mixed.vmin == 0.2
+    assert heatmap_mixed.vmax == 1.0
+
+
+def test_2d_projection_has_unique_segment_keys(heatmap_both_hemispheres):
+    """Projected segments should have unique keys for each hemisphere."""
+    projected, _ = heatmap_both_hemispheres.slicer.get_structures_slice_coords(
+        heatmap_both_hemispheres.regions_meshes,
+        heatmap_both_hemispheres.scene.root,
+    )
+    th_keys = [k for k in projected.keys() if "TH" in k]
+    left_keys = [k for k in th_keys if "TH__left" in k]
+    right_keys = [k for k in th_keys if "TH__right" in k]
+    assert len(left_keys) >= 1
+    assert len(right_keys) >= 1
+
+
+def test_backwards_compatible_scalar_values():
+    """Scalar-only values should work exactly as before."""
+    h = bgh.Heatmap(
+        values={"TH": 1.0, "VISp": 0.5},
+        position=7000,
+        orientation="frontal",
+        format="2D",
+        check_latest=False,
+    )
+    names = {a.name for a in h.regions_meshes}
+    assert "TH" in names
+    assert "VISp" in names
+    assert all("__" not in n for n in names)
+    h.scene.close()
+
+
+# ---------------------------------------------------------------------------
+# hemisphere="left" / "right" for bilateral scalar regions
+# (covers bilateral hemisphere cutting via brainrender hemisphere= param)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def heatmap_bilateral_left_hemisphere():
+    h = bgh.Heatmap(
+        values={"TH": 1.0, "VISp": 0.5},
+        position=7000,
+        orientation="frontal",
+        hemisphere="left",
+        format="2D",
+        check_latest=False,
+    )
+    yield h
+    h.scene.close()
+
+
+@pytest.fixture
+def heatmap_bilateral_right_hemisphere():
+    h = bgh.Heatmap(
+        values={"TH": 1.0},
+        position=7000,
+        orientation="frontal",
+        hemisphere="right",
+        format="2D",
+        check_latest=False,
+    )
+    yield h
+    h.scene.close()
+
+
+def test_bilateral_hemisphere_left_cuts_mesh(
+    heatmap_bilateral_left_hemisphere,
+):
+    """hemisphere='left' should cut bilateral actors to the left side only."""
+    h = heatmap_bilateral_left_hemisphere
+    bounds = h.scene.root._mesh.bounds()
+    import numpy as np
+
+    mid_z = np.array(bounds).reshape(3, 2).mean(axis=1)[2]
+    for actor in h.regions_meshes:
+        verts = actor._mesh.vertices
+        # Left hemisphere: z-axis points Right in ASR space,
+        # so left = z <= mid_z
+        assert (
+            verts[:, 2].max() <= mid_z + 1e-3
+        ), f"Actor {actor.name} has vertices on the right side after left cut"
+
+
+def test_bilateral_hemisphere_right_cuts_mesh(
+    heatmap_bilateral_right_hemisphere,
+):
+    """hemisphere='right' should cut bilateral actors to the right
+    side only."""
+    h = heatmap_bilateral_right_hemisphere
+    bounds = h.scene.root._mesh.bounds()
+    import numpy as np
+
+    mid_z = np.array(bounds).reshape(3, 2).mean(axis=1)[2]
+    for actor in h.regions_meshes:
+        verts = actor._mesh.vertices
+        # Right hemisphere: z-axis points Right in ASR space,
+        # so right = z >= mid_z
+        assert (
+            verts[:, 2].min() >= mid_z - 1e-3
+        ), f"Actor {actor.name} has vertices on the left side after right cut"
+
+
+def test_bilateral_left_hemisphere_colors_assigned(
+    heatmap_bilateral_left_hemisphere,
+):
+    """actor_colors should be populated correctly for
+    hemisphere='left' bilateral."""
+    h = heatmap_bilateral_left_hemisphere
+    assert len(h.actor_colors) == len(h.regions_meshes)
+    for actor, color in h.actor_colors.items():
+        assert color is not None
+        assert "__" not in actor.name
+
+
+# ---------------------------------------------------------------------------
+# plot() standalone method and plot_subplot() branches
+# (covers lines 415-430, 520, 534, 536, 546-550, 552)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def heatmap_for_plot():
+    h = bgh.Heatmap(
+        values={"TH": 1.0, "VISp": 0.5},
+        position=7000,
+        orientation="frontal",
+        format="2D",
+        check_latest=False,
+    )
+    yield h
+    h.scene.close()
+
+
+def test_plot_returns_figure(heatmap_for_plot):
+    """plot() should return a matplotlib Figure."""
+    import matplotlib.pyplot as plt
+
+    fig = heatmap_for_plot.plot(show_cbar=False)
+    assert isinstance(fig, plt.Figure)
+    plt.close("all")
+
+
+def test_plot_saves_file(heatmap_for_plot, tmp_path):
+    """plot() with filename= should write a file to disk."""
+    import matplotlib.pyplot as plt
+
+    out = tmp_path / "heatmap.png"
+    heatmap_for_plot.plot(filename=str(out), show_cbar=False)
+    assert out.exists()
+    assert out.stat().st_size > 0
+    plt.close("all")
+
+
+def test_plot_subplot_label_regions():
+    """label_regions=True should produce a colorbar with correct tick count."""
+    import matplotlib.pyplot as plt
+
+    h = bgh.Heatmap(
+        values={"TH": 1.0, "VISp": 0.5},
+        position=7000,
+        orientation="frontal",
+        format="2D",
+        label_regions=True,
+        check_latest=False,
+    )
+    fig, ax = plt.subplots()
+    fig, ax = h.plot_subplot(fig=fig, ax=ax, show_cbar=True)
+    # Two regions -> two ticks on the colorbar
+    cbar_ax = fig.axes[-1]
+    labels = [t.get_text() for t in cbar_ax.get_yticklabels() if t.get_text()]
+    assert labels == ["TH", "VISp"]
+    plt.close("all")
+    h.scene.close()
+
+
+def test_plot_subplot_label_regions_per_hemisphere():
+    """label_regions=True with per-hemisphere values uses left:/right: keys."""
+    import matplotlib.pyplot as plt
+
+    h = bgh.Heatmap(
+        values={"TH": {"left": 0.8, "right": 0.2}},
+        position=7000,
+        orientation="frontal",
+        format="2D",
+        label_regions=True,
+        check_latest=False,
+    )
+    fig, ax = plt.subplots()
+    fig, ax = h.plot_subplot(fig=fig, ax=ax, show_cbar=True)
+    cbar_ax = fig.axes[-1]
+    # Two entries: left:TH and right:TH
+    labels = [t.get_text() for t in cbar_ax.get_yticklabels() if t.get_text()]
+    assert labels == ["left:TH", "right:TH"]
+    plt.close("all")
+    h.scene.close()
+
+
+def test_plot_subplot_cbar_label(heatmap_for_plot):
+    """cbar_label= should set the colorbar label text."""
+    import matplotlib.pyplot as plt
+
+    fig, ax = plt.subplots()
+    fig, ax = heatmap_for_plot.plot_subplot(
+        fig=fig, ax=ax, show_cbar=True, cbar_label="my label"
+    )
+    cbar_ax = fig.axes[-1]
+    assert cbar_ax.get_ylabel() == "my label"
+    plt.close("all")
+
+
+def test_plot_subplot_hide_axes(heatmap_for_plot):
+    """hide_axes=True should remove axis ticks and labels."""
+    import matplotlib.pyplot as plt
+
+    fig, ax = plt.subplots()
+    fig, ax = heatmap_for_plot.plot_subplot(
+        fig=fig, ax=ax, show_cbar=False, hide_axes=True
+    )
+    assert ax.get_xlabel() == ""
+    assert ax.get_ylabel() == ""
+    assert ax.get_xticks().size == 0
+    assert ax.get_yticks().size == 0
+    plt.close("all")
+
+
+def test_plot_subplot_show_legend(heatmap_for_plot):
+    """show_legend=True should attach a legend to the axes."""
+    import matplotlib.pyplot as plt
+
+    fig, ax = plt.subplots()
+    fig, ax = heatmap_for_plot.plot_subplot(
+        fig=fig, ax=ax, show_cbar=False, show_legend=True
+    )
+    assert ax.get_legend() is not None
+    plt.close("all")
+
+
+# ---------------------------------------------------------------------------
+# check_values error paths (lines 70, 74, 81, 88)
+# ---------------------------------------------------------------------------
+
+
+def test_check_values_unrecognized_region():
+    """Passing an unknown region acronym should raise ValueError."""
+    with pytest.raises(ValueError, match="not recognized"):
+        bgh.Heatmap(
+            values={"NOTAREGION": 1.0},
+            position=7000,
+            orientation="frontal",
+            format="2D",
+            check_latest=False,
+        )
+
+
+def test_check_values_wrong_type_bilateral():
+    """Passing a string as a bilateral value should raise ValueError."""
+    with pytest.raises(ValueError, match="should be floats"):
+        bgh.Heatmap(
+            values={"TH": "high"},
+            position=7000,
+            orientation="frontal",
+            format="2D",
+            check_latest=False,
+        )
+
+
+def test_check_values_wrong_type_per_hemisphere():
+    """Passing a string inside a per-hemisphere dict should raise
+    ValueError."""
+    with pytest.raises(ValueError, match="should be floats"):
+        bgh.Heatmap(
+            values={"TH": {"left": "high", "right": 0.2}},
+            position=7000,
+            orientation="frontal",
+            format="2D",
+            check_latest=False,
+        )
+
+
+def test_check_values_all_nan():
+    """All-NaN values should produce vmin=vmax=NaN without crashing."""
+    import math
+
+    h = bgh.Heatmap(
+        values={"TH": float("nan")},
+        position=7000,
+        orientation="frontal",
+        format="2D",
+        check_latest=False,
+    )
+    assert math.isnan(h.vmin)
+    assert math.isnan(h.vmax)
+    h.scene.close()
+
+
+# ---------------------------------------------------------------------------
+# show() 2D path (line 369)
+# ---------------------------------------------------------------------------
+
+
+def test_show_2d_returns_figure(heatmap_for_plot):
+    """show() in 2D format should return a matplotlib Figure."""
+    import matplotlib.pyplot as plt
+
+    result = heatmap_for_plot.show()
+    assert isinstance(result, plt.Figure)
+    plt.close("all")

--- a/tests/test_unit/test_parse_values.py
+++ b/tests/test_unit/test_parse_values.py
@@ -1,0 +1,76 @@
+import pytest
+
+from brainglobe_heatmap.heatmaps import parse_values
+
+
+def test_all_bilateral():
+    """Scalar-only input is fully backwards compatible."""
+    bilateral, per_hemi = parse_values({"TH": 1.0, "VISp": 0.5})
+    assert bilateral == {"TH": 1.0, "VISp": 0.5}
+    assert per_hemi == {}
+
+
+def test_all_per_hemisphere():
+    """All regions with hemisphere-specific values."""
+    bilateral, per_hemi = parse_values(
+        {
+            "VISp": {"left": 0.8, "right": 0.2},
+        }
+    )
+    assert bilateral == {}
+    assert per_hemi == {"VISp": {"left": 0.8, "right": 0.2}}
+
+
+def test_mixed_bilateral_and_per_hemisphere():
+    """Mix of scalar and per-hemisphere values splits correctly."""
+    bilateral, per_hemi = parse_values(
+        {
+            "TH": 1.0,
+            "VISp": {"left": 0.8, "right": 0.2},
+            "MOp": {"left": 0.5},
+        }
+    )
+    assert bilateral == {"TH": 1.0}
+    assert per_hemi == {
+        "VISp": {"left": 0.8, "right": 0.2},
+        "MOp": {"left": 0.5},
+    }
+
+
+def test_left_only():
+    """Only left hemisphere value specified."""
+    bilateral, per_hemi = parse_values({"VISp": {"left": 0.8}})
+    assert per_hemi == {"VISp": {"left": 0.8}}
+    assert bilateral == {}
+
+
+def test_right_only():
+    """Only right hemisphere value specified."""
+    bilateral, per_hemi = parse_values({"VISp": {"right": 0.3}})
+    assert per_hemi == {"VISp": {"right": 0.3}}
+    assert bilateral == {}
+
+
+def test_invalid_hemisphere_key_raises():
+    """Invalid hemisphere key (not left/right) raises ValueError."""
+    with pytest.raises(ValueError, match="may only contain"):
+        parse_values({"VISp": {"left": 0.8, "center": 0.2}})
+
+
+def test_empty_hemisphere_dict_raises():
+    """Empty per-hemisphere dict raises ValueError."""
+    with pytest.raises(ValueError, match="is empty"):
+        parse_values({"VISp": {}})
+
+
+def test_empty_input():
+    """Empty input returns two empty dicts."""
+    bilateral, per_hemi = parse_values({})
+    assert bilateral == {}
+    assert per_hemi == {}
+
+
+def test_double_underscore_in_region_name_raises():
+    """Region names containing __ are reserved for internal use."""
+    with pytest.raises(ValueError, match="reserved"):
+        parse_values({"TH__left": 1.0})


### PR DESCRIPTION
## Description

**What is this PR**
- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Users currently cannot visualise different values in each hemisphere — a region is treated as a single bilateral structure. This was requested in the [[image.sc forum](https://forum.image.sc/t/allen-spinal-cord-atlas-is-off-axis/99539/4)](https://forum.image.sc/t/allen-spinal-cord-atlas-is-off-axis/99539/4) for use cases like showing an injection affecting one hemisphere more than the other.

**What does this PR do?**

Allows users to pass a dict with `"left"` and/or `"right"` keys as a region value to visualise different colors per hemisphere:

```python
bgh.Heatmap(
    values={
        "TH": 1.0,                             # bilateral (unchanged)
        "VISp": {"left": 0.8, "right": 0.2},  # per-hemisphere
        "MOp": {"left": 0.5},                  # left only
    },
    position=7000,
    orientation="frontal",
    format="2D",
).show()
```

Fully backwards compatible — scalar values behave exactly as before.

## References

Closes #58

## How has this PR been tested?

- 9 unit tests for the new `parse_values()` function covering all input combinations and error cases
- 7 integration tests covering both hemispheres, single side, mixed bilateral+per-hemisphere, 2D projection uniqueness, and backwards compatibility with existing scalar values
- All 54 tests passing, coverage at 74%
- End-to-end `show()` tested in both 2D and 3D modes

Implementation notes:
- Per-hemisphere regions are added as separate actors then manually cut with `cut_with_plane()` — bypasses brainrender's `hemisphere=` param which calls `get_plane()`, broken on numpy>=2.0
- Actors are renamed to `REGION__left` / `REGION__right` so the slicer produces unique segment keys (two actors with the same name would overwrite each other in the projected dict)
- Region names containing `__` are now explicitly rejected as that pattern is reserved for internal hemisphere tracking
- `vmin`/`vmax` computed globally across all values for a consistent colormap scale

## Is this a breaking change?

No. Scalar values work identically to before. The only new restriction is that region names containing `__` are now rejected — no existing atlas acronym uses this pattern (verified across `allen_mouse_25um`, `kim_mouse_25um`, `allen_human_500um`).

## Does this PR require an update to the documentation?

The `values` parameter in `Heatmap.__init__` docstring has been updated to document the new dict syntax. A follow-up documentation PR to brainglobe.info showing a hemisphere-specific example would be useful.

## Checklist:
- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [[pre-commit](https://pre-commit.com/)](https://pre-commit.com/)