### PR TITLE
fix: colorbar region labels positioned by value when label_regions=True

### DIFF
--- a/brainglobe_heatmap/heatmaps.py
+++ b/brainglobe_heatmap/heatmaps.py
@@ -528,26 +528,34 @@ class Heatmap:
 
             # cmap = mpl.cm.cool
             norm = mpl.colors.Normalize(vmin=self.vmin, vmax=self.vmax)
-            if self.label_regions is True:
-                cbar = fig.colorbar(
-                    mpl.cm.ScalarMappable(
-                        norm=None,
-                        cmap=mpl.cm.get_cmap(self.cmap, len(self.values)),
-                    ),
-                    cax=cax,
-                )
-            else:
-                cbar = fig.colorbar(
-                    mpl.cm.ScalarMappable(norm=norm, cmap=self.cmap), cax=cax
-                )
+            cbar = fig.colorbar(
+                mpl.cm.ScalarMappable(norm=norm, cmap=self.cmap), cax=cax
+            )
 
             if cbar_label is not None:
                 cbar.set_label(cbar_label)
 
             if self.label_regions is True:
-                cbar.ax.set_yticklabels(
-                    [r.strip() for r in self.values.keys()]
-                )
+                unique_visible_regions = set()
+                for r in projected.keys():
+                    name = r.split("_segment_")[0]
+                    if name != "root":
+                        unique_visible_regions.add(name)
+
+                visible_regions_values: list[tuple[str, float]] = [
+                    (region, self.values[region])
+                    for region in unique_visible_regions
+                ]
+
+                tick_labels: list[str] = []
+                tick_values: list[float] = []
+                for region, value in visible_regions_values:
+                    if value > self.vmax or value < self.vmin:
+                        continue
+                    tick_labels.append(region)
+                    tick_values.append(value)
+
+                cbar.set_ticks(ticks=tick_values, labels=tick_labels)
 
         # style axes
         ax.invert_yaxis()

--- a/brainglobe_heatmap/heatmaps.py
+++ b/brainglobe_heatmap/heatmaps.py
@@ -549,13 +549,11 @@ class Heatmap:
 
                 if isinstance(self.label_regions, dict):
                     regions_to_label = (
-                        set(self.label_regions.keys())
-                        & unique_visible_regions
+                        set(self.label_regions.keys()) & unique_visible_regions
                     )
                 elif isinstance(self.label_regions, list):
                     regions_to_label = (
-                        set(self.label_regions)
-                        & unique_visible_regions
+                        set(self.label_regions) & unique_visible_regions
                     )
                 else:
                     regions_to_label = unique_visible_regions
@@ -567,9 +565,7 @@ class Heatmap:
                     if value > self.vmax or value < self.vmin:
                         continue
                     if isinstance(self.label_regions, dict):
-                        tick_labels.append(
-                            str(self.label_regions[region])
-                        )
+                        tick_labels.append(str(self.label_regions[region]))
                     else:
                         tick_labels.append(region)
                     tick_values.append(value)

--- a/brainglobe_heatmap/heatmaps.py
+++ b/brainglobe_heatmap/heatmaps.py
@@ -110,7 +110,7 @@ class Heatmap:
         interactive: bool = True,
         zoom: Optional[float] = None,
         atlas_name: Optional[str] = None,
-        label_regions: Optional[bool] = False,
+        label_regions: Optional[Union[bool, List[str], Dict]] = False,
         annotate_regions: Optional[Union[bool, List[str], Dict]] = False,
         annotate_text_options_2d: Optional[Dict] = None,
         check_latest: bool = True,
@@ -154,9 +154,14 @@ class Heatmap:
         atlas_name : str, optional
             Name of the atlas to use for the heatmap.
             If None allen_mouse_25um is used. Default is None.
-        label_regions : bool, optional
-            If True, labels the regions on the colorbar (only valid in 2D).
+        label_regions :
+            bool, List[str], Dict[str, str], optional
+            Controls region labelling on the colorbar (2D only).
+            If True, labels all visible regions.
+            If a list, labels only the specified regions.
+            If a dict, labels specified regions with custom text.
             Default is False.
+
         annotate_regions :
             bool, List[str], Dict[str, Union[str, float, int]], optional
             Controls region annotation in 2D and 3D format.
@@ -535,24 +540,38 @@ class Heatmap:
             if cbar_label is not None:
                 cbar.set_label(cbar_label)
 
-            if self.label_regions is True:
+            if self.label_regions:
                 unique_visible_regions = set()
                 for r in projected.keys():
                     name = r.split("_segment_")[0]
                     if name != "root":
                         unique_visible_regions.add(name)
 
-                visible_regions_values: list[tuple[str, float]] = [
-                    (region, self.values[region])
-                    for region in unique_visible_regions
-                ]
+                if isinstance(self.label_regions, dict):
+                    regions_to_label = (
+                        set(self.label_regions.keys())
+                        & unique_visible_regions
+                    )
+                elif isinstance(self.label_regions, list):
+                    regions_to_label = (
+                        set(self.label_regions)
+                        & unique_visible_regions
+                    )
+                else:
+                    regions_to_label = unique_visible_regions
 
                 tick_labels: list[str] = []
                 tick_values: list[float] = []
-                for region, value in visible_regions_values:
+                for region in regions_to_label:
+                    value = self.values[region]
                     if value > self.vmax or value < self.vmin:
                         continue
-                    tick_labels.append(region)
+                    if isinstance(self.label_regions, dict):
+                        tick_labels.append(
+                            str(self.label_regions[region])
+                        )
+                    else:
+                        tick_labels.append(region)
                     tick_values.append(value)
 
                 cbar.set_ticks(ticks=tick_values, labels=tick_labels)

--- a/tests/test_unit/test_heatmap_2d_colorbar.py
+++ b/tests/test_unit/test_heatmap_2d_colorbar.py
@@ -19,7 +19,7 @@ VALUES = {
 
 @pytest.fixture
 def mock_projected():
-    """Fixture providing mock projected slice data with TH, HIP, and VIS visible."""
+    """Fixture: mock projected slice data with TH, HIP, VIS visible."""
     return {
         "TH_segment_0": np.array([[0, 0], [1, 0], [1, 1], [0, 1]]),
         "TH_segment_1": np.array([[0, 0], [1, 0], [1, 1], [0, 1]]),
@@ -109,7 +109,7 @@ def test_no_region_labels_when_label_regions_false(heatmap_2d, mock_projected):
 def test_region_labels_shown_when_label_regions_true(
     heatmap_2d, mock_projected
 ):
-    """set_ticks must be called once when label_regions=True and show_cbar=True."""
+    """set_ticks called once when label_regions=True and show_cbar=True."""
     heatmap_2d.label_regions = True
     _, mock_colorbar = _show_with_mocks(
         heatmap_2d, mock_projected, show_cbar=True
@@ -118,7 +118,7 @@ def test_region_labels_shown_when_label_regions_true(
 
 
 def test_region_labels_match_visible_regions(heatmap_2d, mock_projected):
-    """Colorbar labels must only include visible regions within vmin/vmax range."""
+    """Colorbar labels must only include visible regions in vmin/vmax range."""
     heatmap_2d.label_regions = True
     _, mock_colorbar = _show_with_mocks(
         heatmap_2d, mock_projected, show_cbar=True
@@ -127,9 +127,10 @@ def test_region_labels_match_visible_regions(heatmap_2d, mock_projected):
     region_labels = kwargs["labels"]
     tick_values = kwargs["ticks"]
 
-    visible_regions = {"TH", "HIP", "VIS"}  # from mock_projected, excluding root
+    visible_regions = {"TH", "HIP", "VIS"}  # from mock_projected, no root
     expected_regions = {
-        r for r in visible_regions
+        r
+        for r in visible_regions
         if heatmap_2d.vmin <= VALUES[r] <= heatmap_2d.vmax
     }
 
@@ -185,7 +186,7 @@ def test_cbar_label_not_set_when_not_provided(heatmap_2d, mock_projected):
 
 
 def test_cbar_label_hidden_when_show_cbar_false(heatmap_2d, mock_projected):
-    """set_label must not be called when show_cbar=False even with cbar_label set."""
+    """set_label not called when show_cbar=False with cbar_label set."""
     _, mock_colorbar = _show_with_mocks(
         heatmap_2d,
         mock_projected,
@@ -210,9 +211,7 @@ def test_colorbar_empty_when_no_visible_regions(heatmap_2d):
 def test_colorbar_empty_when_only_root_visible(heatmap_2d):
     """Colorbar ticks must be empty when only root segment is visible."""
     heatmap_2d.label_regions = True
-    projected = {
-        "root_segment_0": np.array([[0, 0], [1, 0], [1, 1], [0, 1]])
-    }
+    projected = {"root_segment_0": np.array([[0, 0], [1, 0], [1, 1], [0, 1]])}
     _, mock_colorbar = _show_with_mocks(heatmap_2d, projected, show_cbar=True)
     _, kwargs = mock_colorbar.set_ticks.call_args
     assert len(kwargs["ticks"]) == 0
@@ -223,9 +222,7 @@ def test_colorbar_single_region(heatmap_2d):
     """Colorbar must show exactly one tick when one region is visible."""
     heatmap_2d.label_regions = True
     heatmap_2d.values = {"TH": 1.0}
-    projected = {
-        "TH_segment_1": np.array([[0, 0], [1, 0], [1, 1], [0, 1]])
-    }
+    projected = {"TH_segment_1": np.array([[0, 0], [1, 0], [1, 1], [0, 1]])}
     _, mock_colorbar = _show_with_mocks(heatmap_2d, projected, show_cbar=True)
     _, kwargs = mock_colorbar.set_ticks.call_args
     assert len(kwargs["ticks"]) == 1
@@ -235,7 +232,7 @@ def test_colorbar_single_region(heatmap_2d):
 
 
 def test_colorbar_empty_when_all_values_outside_range(heatmap_2d):
-    """Colorbar ticks must be empty when all region values are outside vmin/vmax."""
+    """Colorbar ticks must be empty when all values are outside vmin/vmax."""
     heatmap_2d.label_regions = True
     heatmap_2d.values = {"TH": -6.2, "VIS": 4.1}
     projected = {

--- a/tests/test_unit/test_heatmap_2d_colorbar.py
+++ b/tests/test_unit/test_heatmap_2d_colorbar.py
@@ -1,0 +1,263 @@
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+from brainrender import settings
+
+import brainglobe_heatmap as bgh
+
+settings.INTERACTIVE = False
+settings.OFFSCREEN = True
+
+VALUES = {
+    "TH": 1,
+    "HIP": 3,
+    "VIS": 2,
+    "PA": -4,
+}
+
+
+@pytest.fixture
+def mock_projected():
+    """Fixture providing mock projected slice data with TH, HIP, and VIS visible."""
+    return {
+        "TH_segment_0": np.array([[0, 0], [1, 0], [1, 1], [0, 1]]),
+        "TH_segment_1": np.array([[0, 0], [1, 0], [1, 1], [0, 1]]),
+        "HIP_segment_1": np.array([[0, 0], [1, 0], [1, 1], [0, 1]]),
+        "VIS_segment_0": np.array([[0, 0], [1, 0], [1, 1], [0, 1]]),
+        "VIS_segment_1": np.array([[0, 0], [1, 0], [1, 1], [0, 1]]),
+        "root_segment_0": np.array([[0, 0], [1, 0], [1, 1], [0, 1]]),
+    }
+
+
+@pytest.fixture
+def heatmap_2d():
+    """Fixture for a standard 2D heatmap."""
+    heatmap = bgh.Heatmap(
+        VALUES,
+        format="2D",
+        position=1000,
+        orientation="frontal",
+        vmin=-5,
+        vmax=3,
+        check_latest=False,
+        interactive=False,
+    )
+    yield heatmap
+    heatmap.scene.close()
+
+
+def _show_with_mocks(heatmap, mock_projected, **show_kwargs):
+    """Helper to call heatmap.show() with slicer and matplotlib mocked."""
+    mock_colorbar = MagicMock()
+    with (
+        patch.object(
+            heatmap.slicer,
+            "get_structures_slice_coords",
+            return_value=(mock_projected, None),
+        ),
+        patch(
+            "matplotlib.figure.Figure.colorbar", return_value=mock_colorbar
+        ) as mock_colorbar_fn,
+        patch("matplotlib.pyplot.show"),
+    ):
+        heatmap.show(**show_kwargs)
+    return mock_colorbar_fn, mock_colorbar
+
+
+# --- Colorbar visibility tests ---
+
+
+def test_colorbar_hidden_when_show_cbar_false(heatmap_2d, mock_projected):
+    """Colorbar must not be created when show_cbar=False."""
+    mock_colorbar_fn, _ = _show_with_mocks(
+        heatmap_2d, mock_projected, show_cbar=False
+    )
+    assert mock_colorbar_fn.call_count == 0
+
+
+def test_colorbar_shown_when_show_cbar_true(heatmap_2d, mock_projected):
+    """Colorbar must be created when show_cbar=True."""
+    mock_colorbar_fn, _ = _show_with_mocks(
+        heatmap_2d, mock_projected, show_cbar=True
+    )
+    assert mock_colorbar_fn.call_count == 1
+
+
+def test_show_cbar_false_overrides_label_regions(heatmap_2d, mock_projected):
+    """show_cbar=False must suppress colorbar even when label_regions=True."""
+    heatmap_2d.label_regions = True
+    mock_colorbar_fn, mock_colorbar = _show_with_mocks(
+        heatmap_2d, mock_projected, show_cbar=False
+    )
+    assert mock_colorbar_fn.call_count == 0
+    assert mock_colorbar.set_ticks.call_count == 0
+
+
+# --- Region label tests ---
+
+
+def test_no_region_labels_when_label_regions_false(heatmap_2d, mock_projected):
+    """set_ticks must not be called when label_regions=False."""
+    heatmap_2d.label_regions = False
+    _, mock_colorbar = _show_with_mocks(
+        heatmap_2d, mock_projected, show_cbar=True
+    )
+    assert mock_colorbar.set_ticks.call_count == 0
+
+
+def test_region_labels_shown_when_label_regions_true(
+    heatmap_2d, mock_projected
+):
+    """set_ticks must be called once when label_regions=True and show_cbar=True."""
+    heatmap_2d.label_regions = True
+    _, mock_colorbar = _show_with_mocks(
+        heatmap_2d, mock_projected, show_cbar=True
+    )
+    assert mock_colorbar.set_ticks.call_count == 1
+
+
+def test_region_labels_match_visible_regions(heatmap_2d, mock_projected):
+    """Colorbar labels must only include visible regions within vmin/vmax range."""
+    heatmap_2d.label_regions = True
+    _, mock_colorbar = _show_with_mocks(
+        heatmap_2d, mock_projected, show_cbar=True
+    )
+    _, kwargs = mock_colorbar.set_ticks.call_args
+    region_labels = kwargs["labels"]
+    tick_values = kwargs["ticks"]
+
+    visible_regions = {"TH", "HIP", "VIS"}  # from mock_projected, excluding root
+    expected_regions = {
+        r for r in visible_regions
+        if heatmap_2d.vmin <= VALUES[r] <= heatmap_2d.vmax
+    }
+
+    assert set(region_labels) == expected_regions
+    assert "root" not in region_labels
+    assert len(tick_values) == len(expected_regions)
+
+
+def test_region_tick_values_match_region_values(heatmap_2d, mock_projected):
+    """Each colorbar tick value must match the corresponding region's value."""
+    heatmap_2d.label_regions = True
+    _, mock_colorbar = _show_with_mocks(
+        heatmap_2d, mock_projected, show_cbar=True
+    )
+    _, kwargs = mock_colorbar.set_ticks.call_args
+    region_labels = kwargs["labels"]
+    tick_values = kwargs["ticks"]
+
+    for i, region in enumerate(region_labels):
+        assert tick_values[i] == VALUES[region]
+
+
+def test_region_tick_values_within_vmin_vmax(heatmap_2d, mock_projected):
+    """All colorbar tick values must be within vmin/vmax range."""
+    heatmap_2d.label_regions = True
+    _, mock_colorbar = _show_with_mocks(
+        heatmap_2d, mock_projected, show_cbar=True
+    )
+    _, kwargs = mock_colorbar.set_ticks.call_args
+    tick_values = kwargs["ticks"]
+
+    for val in tick_values:
+        assert heatmap_2d.vmin <= val <= heatmap_2d.vmax
+
+
+# --- cbar_label tests ---
+
+
+def test_cbar_label_set_when_provided(heatmap_2d, mock_projected):
+    """set_label must be called when cbar_label is provided."""
+    _, mock_colorbar = _show_with_mocks(
+        heatmap_2d, mock_projected, show_cbar=True, cbar_label="Test Label"
+    )
+    assert mock_colorbar.set_label.call_count == 1
+
+
+def test_cbar_label_not_set_when_not_provided(heatmap_2d, mock_projected):
+    """set_label must not be called when cbar_label is not provided."""
+    _, mock_colorbar = _show_with_mocks(
+        heatmap_2d, mock_projected, show_cbar=True
+    )
+    assert mock_colorbar.set_label.call_count == 0
+
+
+def test_cbar_label_hidden_when_show_cbar_false(heatmap_2d, mock_projected):
+    """set_label must not be called when show_cbar=False even with cbar_label set."""
+    _, mock_colorbar = _show_with_mocks(
+        heatmap_2d,
+        mock_projected,
+        show_cbar=False,
+        cbar_label="Test Label",
+    )
+    assert mock_colorbar.set_label.call_count == 0
+
+
+# --- Edge case tests ---
+
+
+def test_colorbar_empty_when_no_visible_regions(heatmap_2d):
+    """Colorbar ticks must be empty when no regions are visible."""
+    heatmap_2d.label_regions = True
+    _, mock_colorbar = _show_with_mocks(heatmap_2d, {}, show_cbar=True)
+    _, kwargs = mock_colorbar.set_ticks.call_args
+    assert len(kwargs["ticks"]) == 0
+    assert len(kwargs["labels"]) == 0
+
+
+def test_colorbar_empty_when_only_root_visible(heatmap_2d):
+    """Colorbar ticks must be empty when only root segment is visible."""
+    heatmap_2d.label_regions = True
+    projected = {
+        "root_segment_0": np.array([[0, 0], [1, 0], [1, 1], [0, 1]])
+    }
+    _, mock_colorbar = _show_with_mocks(heatmap_2d, projected, show_cbar=True)
+    _, kwargs = mock_colorbar.set_ticks.call_args
+    assert len(kwargs["ticks"]) == 0
+    assert len(kwargs["labels"]) == 0
+
+
+def test_colorbar_single_region(heatmap_2d):
+    """Colorbar must show exactly one tick when one region is visible."""
+    heatmap_2d.label_regions = True
+    heatmap_2d.values = {"TH": 1.0}
+    projected = {
+        "TH_segment_1": np.array([[0, 0], [1, 0], [1, 1], [0, 1]])
+    }
+    _, mock_colorbar = _show_with_mocks(heatmap_2d, projected, show_cbar=True)
+    _, kwargs = mock_colorbar.set_ticks.call_args
+    assert len(kwargs["ticks"]) == 1
+    assert len(kwargs["labels"]) == 1
+    assert kwargs["labels"][0] == "TH"
+    assert kwargs["ticks"][0] == 1.0
+
+
+def test_colorbar_empty_when_all_values_outside_range(heatmap_2d):
+    """Colorbar ticks must be empty when all region values are outside vmin/vmax."""
+    heatmap_2d.label_regions = True
+    heatmap_2d.values = {"TH": -6.2, "VIS": 4.1}
+    projected = {
+        "TH_segment_0": np.array([[0, 0], [1, 0], [1, 1], [0, 1]]),
+        "VIS_segment_0": np.array([[0, 0], [1, 0], [1, 1], [0, 1]]),
+    }
+    _, mock_colorbar = _show_with_mocks(heatmap_2d, projected, show_cbar=True)
+    _, kwargs = mock_colorbar.set_ticks.call_args
+    assert len(kwargs["ticks"]) == 0
+    assert len(kwargs["labels"]) == 0
+
+
+def test_colorbar_only_in_range_regions_shown(heatmap_2d):
+    """Colorbar must only show regions whose values are within vmin/vmax."""
+    heatmap_2d.label_regions = True
+    heatmap_2d.values = {"TH": -6.2, "VIS": 1.1, "HIP": 5}
+    projected = {
+        "TH_segment_0": np.array([[0, 0], [1, 0], [1, 1], [0, 1]]),
+        "HIP_segment_0": np.array([[0, 0], [1, 0], [1, 1], [0, 1]]),
+        "VIS_segment_0": np.array([[0, 0], [1, 0], [1, 1], [0, 1]]),
+    }
+    _, mock_colorbar = _show_with_mocks(heatmap_2d, projected, show_cbar=True)
+    _, kwargs = mock_colorbar.set_ticks.call_args
+    assert kwargs["labels"] == ["VIS"]
+    assert kwargs["ticks"][0] == 1.1

--- a/tests/test_unit/test_heatmap_2d_colorbar.py
+++ b/tests/test_unit/test_heatmap_2d_colorbar.py
@@ -258,3 +258,90 @@ def test_colorbar_only_in_range_regions_shown(heatmap_2d):
     _, kwargs = mock_colorbar.set_ticks.call_args
     assert kwargs["labels"] == ["VIS"]
     assert kwargs["ticks"][0] == 1.1
+
+
+# --- List and Dict label_regions tests ---
+
+
+def test_label_regions_list_only_specified_regions(
+    heatmap_2d, mock_projected
+):
+    """Only regions in the list should be labelled."""
+    heatmap_2d.label_regions = ["TH", "VIS"]
+    _, mock_colorbar = _show_with_mocks(
+        heatmap_2d, mock_projected, show_cbar=True
+    )
+    _, kwargs = mock_colorbar.set_ticks.call_args
+    assert set(kwargs["labels"]) == {"TH", "VIS"}
+    assert len(kwargs["ticks"]) == 2
+
+
+def test_label_regions_list_ignores_non_visible(
+    heatmap_2d, mock_projected
+):
+    """Regions in the list but not visible should be ignored."""
+    heatmap_2d.label_regions = ["TH", "PA"]
+    _, mock_colorbar = _show_with_mocks(
+        heatmap_2d, mock_projected, show_cbar=True
+    )
+    _, kwargs = mock_colorbar.set_ticks.call_args
+    assert kwargs["labels"] == ["TH"]
+    assert kwargs["ticks"] == [1]
+
+
+def test_label_regions_list_excludes_out_of_range(heatmap_2d):
+    """List regions with values outside vmin/vmax are excluded."""
+    heatmap_2d.label_regions = ["TH", "VIS"]
+    heatmap_2d.values = {"TH": -6.2, "VIS": 1.1}
+    projected = {
+        "TH_segment_0": np.array([[0, 0], [1, 0], [1, 1], [0, 1]]),
+        "VIS_segment_0": np.array([[0, 0], [1, 0], [1, 1], [0, 1]]),
+    }
+    _, mock_colorbar = _show_with_mocks(
+        heatmap_2d, projected, show_cbar=True
+    )
+    _, kwargs = mock_colorbar.set_ticks.call_args
+    assert kwargs["labels"] == ["VIS"]
+    assert kwargs["ticks"][0] == 1.1
+
+
+def test_label_regions_dict_custom_labels(
+    heatmap_2d, mock_projected
+):
+    """Dict values should be used as custom label text."""
+    heatmap_2d.label_regions = {"TH": "Thalamus", "VIS": "Visual"}
+    _, mock_colorbar = _show_with_mocks(
+        heatmap_2d, mock_projected, show_cbar=True
+    )
+    _, kwargs = mock_colorbar.set_ticks.call_args
+    assert set(kwargs["labels"]) == {"Thalamus", "Visual"}
+    assert len(kwargs["ticks"]) == 2
+
+
+def test_label_regions_dict_ignores_non_visible(
+    heatmap_2d, mock_projected
+):
+    """Dict regions not visible in the slice should be ignored."""
+    heatmap_2d.label_regions = {"TH": "Thalamus", "PA": "Parietal"}
+    _, mock_colorbar = _show_with_mocks(
+        heatmap_2d, mock_projected, show_cbar=True
+    )
+    _, kwargs = mock_colorbar.set_ticks.call_args
+    assert kwargs["labels"] == ["Thalamus"]
+    assert kwargs["ticks"] == [1]
+
+
+def test_label_regions_dict_excludes_out_of_range(heatmap_2d):
+    """Dict regions with values outside vmin/vmax are excluded."""
+    heatmap_2d.label_regions = {"TH": "Thalamus", "VIS": "Visual"}
+    heatmap_2d.values = {"TH": -6.2, "VIS": 1.1}
+    projected = {
+        "TH_segment_0": np.array([[0, 0], [1, 0], [1, 1], [0, 1]]),
+        "VIS_segment_0": np.array([[0, 0], [1, 0], [1, 1], [0, 1]]),
+    }
+    _, mock_colorbar = _show_with_mocks(
+        heatmap_2d, projected, show_cbar=True
+    )
+    _, kwargs = mock_colorbar.set_ticks.call_args
+    assert kwargs["labels"] == ["Visual"]
+    assert kwargs["ticks"][0] == 1.1

--- a/tests/test_unit/test_heatmap_2d_colorbar.py
+++ b/tests/test_unit/test_heatmap_2d_colorbar.py
@@ -263,9 +263,7 @@ def test_colorbar_only_in_range_regions_shown(heatmap_2d):
 # --- List and Dict label_regions tests ---
 
 
-def test_label_regions_list_only_specified_regions(
-    heatmap_2d, mock_projected
-):
+def test_label_regions_list_only_specified_regions(heatmap_2d, mock_projected):
     """Only regions in the list should be labelled."""
     heatmap_2d.label_regions = ["TH", "VIS"]
     _, mock_colorbar = _show_with_mocks(
@@ -276,9 +274,7 @@ def test_label_regions_list_only_specified_regions(
     assert len(kwargs["ticks"]) == 2
 
 
-def test_label_regions_list_ignores_non_visible(
-    heatmap_2d, mock_projected
-):
+def test_label_regions_list_ignores_non_visible(heatmap_2d, mock_projected):
     """Regions in the list but not visible should be ignored."""
     heatmap_2d.label_regions = ["TH", "PA"]
     _, mock_colorbar = _show_with_mocks(
@@ -297,17 +293,13 @@ def test_label_regions_list_excludes_out_of_range(heatmap_2d):
         "TH_segment_0": np.array([[0, 0], [1, 0], [1, 1], [0, 1]]),
         "VIS_segment_0": np.array([[0, 0], [1, 0], [1, 1], [0, 1]]),
     }
-    _, mock_colorbar = _show_with_mocks(
-        heatmap_2d, projected, show_cbar=True
-    )
+    _, mock_colorbar = _show_with_mocks(heatmap_2d, projected, show_cbar=True)
     _, kwargs = mock_colorbar.set_ticks.call_args
     assert kwargs["labels"] == ["VIS"]
     assert kwargs["ticks"][0] == 1.1
 
 
-def test_label_regions_dict_custom_labels(
-    heatmap_2d, mock_projected
-):
+def test_label_regions_dict_custom_labels(heatmap_2d, mock_projected):
     """Dict values should be used as custom label text."""
     heatmap_2d.label_regions = {"TH": "Thalamus", "VIS": "Visual"}
     _, mock_colorbar = _show_with_mocks(
@@ -318,9 +310,7 @@ def test_label_regions_dict_custom_labels(
     assert len(kwargs["ticks"]) == 2
 
 
-def test_label_regions_dict_ignores_non_visible(
-    heatmap_2d, mock_projected
-):
+def test_label_regions_dict_ignores_non_visible(heatmap_2d, mock_projected):
     """Dict regions not visible in the slice should be ignored."""
     heatmap_2d.label_regions = {"TH": "Thalamus", "PA": "Parietal"}
     _, mock_colorbar = _show_with_mocks(
@@ -339,9 +329,7 @@ def test_label_regions_dict_excludes_out_of_range(heatmap_2d):
         "TH_segment_0": np.array([[0, 0], [1, 0], [1, 1], [0, 1]]),
         "VIS_segment_0": np.array([[0, 0], [1, 0], [1, 1], [0, 1]]),
     }
-    _, mock_colorbar = _show_with_mocks(
-        heatmap_2d, projected, show_cbar=True
-    )
+    _, mock_colorbar = _show_with_mocks(heatmap_2d, projected, show_cbar=True)
     _, kwargs = mock_colorbar.set_ticks.call_args
     assert kwargs["labels"] == ["Visual"]
     assert kwargs["ticks"][0] == 1.1


### PR DESCRIPTION
Fixes #85

Picks up from the work done in #86 by @zenWai, which was closed without merging. Addresses the review feedback from @alessandrofelder.

## Changes

- `heatmaps.py` — single method for colorbar creation; colorbar labels now show only regions visible in the current subplot, positioned at their actual values; regions outside vmin/vmax are excluded
- `tests/test_unit/test_heatmap_2d_colorbar.py` — rewrote tests per review feedback: split into focused single-purpose tests, `mock_projected` moved to a `@pytest.fixture`, removed the long if/elif chain in edge case tests

## Checklist
- [x] Tests pass locally (54 passed)
- [x] All new functionality covered by tests
- [x] Backward compatible