### PR TITLE
Improve unit test coverage for plane and slicer geometry logic

### DIFF
--- a/tests/test_unit/test_plane.py
+++ b/tests/test_unit/test_plane.py
@@ -1,0 +1,59 @@
+import numpy as np
+import pytest
+from brainglobe_heatmap.plane import Plane
+
+def test_plane_normal_computation():
+    origin = np.array([0, 0, 0])
+    u = np.array([1, 0, 0])
+    v = np.array([0, 1, 0])
+
+    plane = Plane(origin, u, v)
+
+    assert np.allclose(plane.normal, np.array([0, 0, 1]))
+
+def test_plane_non_orthogonal_vectors_raise():
+    origin = np.array([0, 0, 0])
+    u = np.array([1, 0, 0])
+    v = np.array([1, 0, 0])
+
+    with pytest.raises(AssertionError):
+        Plane(origin, u, v)
+
+def test_from_norm_creates_valid_plane():
+    origin = np.array([0, 0, 0])
+    normal = np.array([0, 0, 1])
+
+    plane = Plane.from_norm(origin, normal)
+
+    assert np.allclose(
+        np.abs(plane.normal),
+        np.array([0, 0, 1])
+    )
+
+def test_p3_to_p2_projection():
+    origin = np.array([0, 0, 0])
+    u = np.array([1, 0, 0])
+    v = np.array([0, 1, 0])
+
+    plane = Plane(origin, u, v)
+    
+    points_3d = np.array([
+        [1, 2, 0],
+        [3, 4, 0]
+    ])
+
+    projected = plane.p3_to_p2(points_3d)
+
+    assert np.allclose(projected, np.array([
+        [1, 2],
+        [3, 4]
+    ]))
+
+def test_center_of_mass_returns_origin():
+    origin = np.array([5, 6, 7])
+    u = np.array([1, 0, 0])
+    v = np.array([0, 1, 0])
+
+    plane = Plane(origin, u, v)
+
+    assert np.allclose(plane.center_of_mass(), origin)

--- a/tests/test_unit/test_plane.py
+++ b/tests/test_unit/test_plane.py
@@ -29,7 +29,7 @@ def test_from_norm_creates_valid_plane():
 
     plane = Plane.from_norm(origin, normal)
 
-    assert np.allclose(np.abs(plane.normal), np.array([0, 0, 1]))
+    assert np.allclose(plane.normal, np.array([0, 0, 1]))
 
 
 def test_p3_to_p2_projection():

--- a/tests/test_unit/test_plane.py
+++ b/tests/test_unit/test_plane.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pytest
+
 from brainglobe_heatmap.plane import Plane
+
 
 def test_plane_normal_computation():
     origin = np.array([0, 0, 0])
@@ -11,6 +13,7 @@ def test_plane_normal_computation():
 
     assert np.allclose(plane.normal, np.array([0, 0, 1]))
 
+
 def test_plane_non_orthogonal_vectors_raise():
     origin = np.array([0, 0, 0])
     u = np.array([1, 0, 0])
@@ -19,16 +22,15 @@ def test_plane_non_orthogonal_vectors_raise():
     with pytest.raises(AssertionError):
         Plane(origin, u, v)
 
+
 def test_from_norm_creates_valid_plane():
     origin = np.array([0, 0, 0])
     normal = np.array([0, 0, 1])
 
     plane = Plane.from_norm(origin, normal)
 
-    assert np.allclose(
-        np.abs(plane.normal),
-        np.array([0, 0, 1])
-    )
+    assert np.allclose(np.abs(plane.normal), np.array([0, 0, 1]))
+
 
 def test_p3_to_p2_projection():
     origin = np.array([0, 0, 0])
@@ -36,18 +38,13 @@ def test_p3_to_p2_projection():
     v = np.array([0, 1, 0])
 
     plane = Plane(origin, u, v)
-    
-    points_3d = np.array([
-        [1, 2, 0],
-        [3, 4, 0]
-    ])
+
+    points_3d = np.array([[1, 2, 0], [3, 4, 0]])
 
     projected = plane.p3_to_p2(points_3d)
 
-    assert np.allclose(projected, np.array([
-        [1, 2],
-        [3, 4]
-    ]))
+    assert np.allclose(projected, np.array([[1, 2], [3, 4]]))
+
 
 def test_center_of_mass_returns_origin():
     origin = np.array([5, 6, 7])

--- a/tests/test_unit/test_slicer.py
+++ b/tests/test_unit/test_slicer.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock
+
 import numpy as np
 import pytest
 
@@ -28,18 +30,14 @@ def test_get_ax_idx_case_sensitive():
         get_ax_idx("Frontal")
 
 
-class DummyRoot:
-    def center_of_mass(self):
-        return np.array([0, 0, 0])
-
-
 def test_position_float_with_vector_orientation_raises():
-    dummy_root = DummyRoot()
+    root = MagicMock()
+    root.center_of_mass.return_value = np.array([0, 0, 0])
 
     with pytest.raises(ValueError):
         Slicer(
             position=10,
             orientation=np.array([1, 0, 0]),
             thickness=5,
-            root=dummy_root,
+            root=root,
         )

--- a/tests/test_unit/test_slicer.py
+++ b/tests/test_unit/test_slicer.py
@@ -1,35 +1,38 @@
-import pytest
 import numpy as np
-from brainglobe_heatmap.slicer import get_ax_idx
-from brainglobe_heatmap.slicer import Slicer
+import pytest
+
+from brainglobe_heatmap.slicer import Slicer, get_ax_idx
+
 
 def test_get_ax_idx_frontal():
     assert get_ax_idx("frontal") == 0
 
+
 def test_get_ax_idx_sagittal():
     assert get_ax_idx("sagittal") == 2
 
+
 def test_get_ax_idx_horizontal():
     assert get_ax_idx("horizontal") == 1
+
 
 def test_get_ax_idx_invalid():
     with pytest.raises(ValueError) as excinfo:
         get_ax_idx("invalid")
 
-    assert 'not recognized' in str(excinfo.value)
+    assert "not recognized" in str(excinfo.value)
+
 
 def test_get_ax_idx_case_sensitive():
     with pytest.raises(ValueError):
         get_ax_idx("Frontal")
 
-#def test_slicer_invalid_orientation():
-#    with pytest.raises(ValueError):
-#        Slicer(position=0, orientation="invalid", thickness=10)
 
 class DummyRoot:
     def center_of_mass(self):
         return np.array([0, 0, 0])
-    
+
+
 def test_position_float_with_vector_orientation_raises():
     dummy_root = DummyRoot()
 
@@ -40,15 +43,3 @@ def test_position_float_with_vector_orientation_raises():
             thickness=5,
             root=dummy_root,
         )
-
-'''def test_position_none_uses_center_of_mass():
-    dummy_root = DummyRoot()
-
-    slicer = Slicer(
-        position=None,
-        orientation="frontal",
-        thickness=5,
-        root=dummy_root,
-    )
-
-    assert slicer is not None'''

--- a/tests/test_unit/test_slicer.py
+++ b/tests/test_unit/test_slicer.py
@@ -1,0 +1,54 @@
+import pytest
+import numpy as np
+from brainglobe_heatmap.slicer import get_ax_idx
+from brainglobe_heatmap.slicer import Slicer
+
+def test_get_ax_idx_frontal():
+    assert get_ax_idx("frontal") == 0
+
+def test_get_ax_idx_sagittal():
+    assert get_ax_idx("sagittal") == 2
+
+def test_get_ax_idx_horizontal():
+    assert get_ax_idx("horizontal") == 1
+
+def test_get_ax_idx_invalid():
+    with pytest.raises(ValueError) as excinfo:
+        get_ax_idx("invalid")
+
+    assert 'not recognized' in str(excinfo.value)
+
+def test_get_ax_idx_case_sensitive():
+    with pytest.raises(ValueError):
+        get_ax_idx("Frontal")
+
+#def test_slicer_invalid_orientation():
+#    with pytest.raises(ValueError):
+#        Slicer(position=0, orientation="invalid", thickness=10)
+
+class DummyRoot:
+    def center_of_mass(self):
+        return np.array([0, 0, 0])
+    
+def test_position_float_with_vector_orientation_raises():
+    dummy_root = DummyRoot()
+
+    with pytest.raises(ValueError):
+        Slicer(
+            position=10,
+            orientation=np.array([1, 0, 0]),
+            thickness=5,
+            root=dummy_root,
+        )
+
+'''def test_position_none_uses_center_of_mass():
+    dummy_root = DummyRoot()
+
+    slicer = Slicer(
+        position=None,
+        orientation="frontal",
+        thickness=5,
+        root=dummy_root,
+    )
+
+    assert slicer is not None'''


### PR DESCRIPTION
## Description

**What is this PR**
- [✔️] Other
Unit Test Coverage for the plane and slicing components of brainglobe-heatmap.

**Why is this PR needed?**
The slicing pipeline depends on the geometric accuracy within the plane.py and slicer.py. Improving unit test coverage for mathematical core of the code to increase the reliability and secure foundation for future enhancements or feature implementation.

**What does this PR do?**
This PR adds unit tests covering:
1. Plane
- Computation of Normal vectors
- Validation of Orthonormal basis
- Construction via from_norm
- 3D -> 2D projection logic `(p3_to_p2)`
- `center_of_mass`

2. Slicer
- `get_ax_idx` orientation handling
- Validation of invalid orientation and position combinations

3. No functional changes were made.
4. Improves coverage without modifying existing functionality.

## References

[Brainglobe Heatmap Documentation](https://brainglobe.info/documentation/brainglobe-heatmap/index.html)

## How has this PR been tested?

- All tests were run locally using pytest and ensured existing implementation and unit test continue to pass. 
- Pre-commit checks passed.
- Coverage was verified using.
`pytest --cov=brainglobe_heatmap --cov-report=term-missing`

- Coverage Impact:
-- plane.py: 70% → 88%
-- slicer.py: 58% → 66%
-- Overall coverage: 71% → 74%

## Is this a breaking change?
No

## Does this PR require an update to the documentation?
No

## Checklist:

- [✔️] The code has been tested locally
- [✔️] Tests have been added to cover all new functionality (unit & integration)
- [✔️] The code has been formatted with pre-commit