### PR TITLE
Fix 2D from rendering a straight line on specific cases.

### DIFF
--- a/brainglobe_heatmap/plane.py
+++ b/brainglobe_heatmap/plane.py
@@ -72,6 +72,8 @@ class Plane:
         projected = {}
         for actor in actors:
             mesh: vd.Mesh = actor._mesh
+            if not mesh.is_closed():
+                mesh = mesh.clone().cap()
             intersection = self.intersect_with(mesh)
             if not intersection.vertices.shape[0]:
                 continue


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix

**Why is this PR needed?**
<table>
<tr>
<td>

<pre lang="python"><code>import brainglobe_heatmap as bgh

values = dict(arb=3)
f = bgh.Heatmap(
    values,
    position=11500,
    orientation="frontal",
    title="arb 11500 frontal",
    vmin=-5,
    vmax=3,
    format="2D",
).show(filename="arb_11500_frontal.png")
</code></pre>

</td>
<td>
<a href="https://github.com/user-attachments/assets/4e6129b9-66a5-448f-8759-e1f2121049cb">
  <img width="300" alt="arb_11500_frontal" src="https://github.com/user-attachments/assets/4e6129b9-66a5-448f-8759-e1f2121049cb" />
</a>

</td>
</tr>
</table>

This issue was not identified before because matplotlib's fill() auto-closes projected segments by connecting the last vertex to the first and at most positions the contours happen to be closed or have the first and last vertex near each other.

In this case the issue is visible because the gap between first and last vertex is large, and matplotlib's produces this straight-line.

**What does this PR do?**

Cap unclosed meshes before plane intersection to reduce large gaps. Without this, large gaps in the intersection are auto-closed by matplotlib's fill() with a straight line.
<a href="https://github.com/user-attachments/assets/411616b0-c6f5-476a-9ec5-ab282173f4a0">
  <img width="300" alt="arb_11500_frontal_cap" src="https://github.com/user-attachments/assets/411616b0-c6f5-476a-9ec5-ab282173f4a0" />

## References

Please reference any existing issues/PRs that relate to this PR.

## How has this PR been tested?

- arb at position 11500 frontal
- Verified hemisphere="left" and "right" still render correctly
- Tested multiple regions at multiple positions
- All examples
- Confirmed cap does not degrade with repeated calls and calling it 100 times produces visually identical results.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
