### PR TITLE
Increase MaximumLength of vedo's Mesh.join(reset=True)

### DIFF
--- a/brainglobe_heatmap/plane.py
+++ b/brainglobe_heatmap/plane.py
@@ -78,14 +78,14 @@ class Plane:
             pieces = intersection.split()  # intersection.split() in newer vedo
             for piece_n, piece in enumerate(pieces):
                 # sort coordinates
-                points = self._join_reset(piece)
+                points = self._join_reset(piece).vertices
                 projected[actor.name + f"_segment_{piece_n}"] = self.p3_to_p2(
                     points
                 )
         return projected
 
     @staticmethod
-    def _join_reset(piece: vd.Mesh) -> np.ndarray:
+    def _join_reset(piece: vd.Mesh) -> vd.Mesh:
         """
         Replicates vedo's Mesh.join(reset=True) with MaximumLength
         raised from the default 1000.
@@ -116,4 +116,4 @@ class Plane:
         vpts = poly.GetCell(0).GetPoints().GetData()
         poly.GetPoints().SetData(vpts)
 
-        return poly.GetPoints().GetData()
+        return vd.Mesh(poly)

--- a/tests/test_unit/test_join_reset.py
+++ b/tests/test_unit/test_join_reset.py
@@ -1,57 +1,45 @@
 """Tests for Plane._join_reset( )"""
 
 import numpy as np
-import pytest
-from brainrender.scene import Scene
+import vedo as vd
 
 from brainglobe_heatmap.plane import Plane
-from brainglobe_heatmap.slicer import Slicer
 
 
-@pytest.fixture(scope="module")
-def allen_scene():
-    return Scene(check_latest=False)
+def _get_piece(res):
+    sphere = vd.Sphere(r=1, res=res)
+    cells = sphere.cells
+    np.random.RandomState(66).shuffle(cells)
+    mesh = vd.Mesh([sphere.vertices, cells])
 
-
-@pytest.fixture(scope="module")
-def kim_scene():
-    return Scene(atlas_name="kim_mouse_10um", check_latest=False)
-
-
-# Current root broken position for kim
-# ex: 7100, 9100, 9200
-POSITION = 9100
-
-
-def _get_piece(scene):
-    slicer = Slicer(
-        position=POSITION, orientation="frontal", thickness=10, root=scene.root
+    plane = Plane(
+        origin=np.array([0.0, 0.0, 0.0]),
+        u=np.array([1.0, 0.0, 0.0]),
+        v=np.array([0.0, 1.0, 0.0]),
     )
-    intersection = slicer.plane0.intersect_with(scene.root._mesh)
+    intersection = plane.intersect_with(mesh)
     return intersection.split()[0]
 
 
 # asserts that _join_reset VS join(reset=True)
 # produces same result on simple cases
-def test_join_reset_matches_vedo_join(allen_scene):
-    piece = _get_piece(allen_scene)
+def test_join_reset_matches_vedo_join():
+    piece = _get_piece(res=100)
 
-    ours = Plane._join_reset(piece)
+    _join_reset = Plane._join_reset(piece).vertices
     vedos = piece.join(reset=True).vertices
 
-    np.testing.assert_array_equal(ours, vedos)
+    np.testing.assert_array_equal(_join_reset, vedos)
 
 
 # asserts that vedo's join(reset=True) loses data
 # due to its default SetMaximumLength
-# particularly testing kim_10um ${POSITION}
-def test_join_reset_handles_kim_root(kim_scene):
-    piece = _get_piece(kim_scene)
+def test_join_reset_handles_kim_root():
+    piece = _get_piece(res=1000)
 
-    ours = Plane._join_reset(piece)
+    _join_reset = Plane._join_reset(piece).vertices
     vedos = piece.join(reset=True).vertices
 
-    # If the test fails maybe would need to
-    # hard test a different position
-    # or no need to increase MaximumLength anymore
-    assert ours.shape[0] > vedos.shape[0]
+    # If the test fails maybe
+    # there is no need to increase MaximumLength anymore
+    assert _join_reset.shape[0] > vedos.shape[0]


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix

## **Why is this PR needed?**
<table>
<tr>
<td>

<pre lang="python"><code>import brainglobe_heatmap as bgh
values = dict(CL=1,CM=2, PAG=3)
position = 9100 # or 7100 9200
f = bgh.Heatmap(
    values,
    position,
    orientation="frontal",
    title=f"kim10um frontal {position}",
    atlas_name="kim_mouse_10um",
    vmin=-5,
    vmax=3,
    format="2D",
).show()
</code></pre>

</td>
<td>
<a href="https://github.com/user-attachments/assets/f5d71ca2-dd24-4dfe-b02d-799a52e78910">
  <img width="230" alt="kim10um_frontal_7100_before" src="https://github.com/user-attachments/assets/f5d71ca2-dd24-4dfe-b02d-799a52e78910" />
</a>

</td>

</td>
<td>
<a href="https://github.com/user-attachments/assets/4e17fb3c-3339-47ce-8759-b0cce22ca8c1">
  <img width="230" alt="kim10um_frontal_9100_before" src="https://github.com/user-attachments/assets/4e17fb3c-3339-47ce-8759-b0cce22ca8c1" />
</a>

</td>
</tr>
</table>
vedo's join(reset=True) uses vtkStripper with its default MaximumLength=1000. For high-resolution atlases like kim_mouse_10um, the root contour exceeds this limit, causing the stripper to split it into multiple cells and when it gets split into multiple cells, only the first cell is kept causing the issue seen above.


## **What does this PR do?**

Replicate vedo's join(reset=True) with the limit raised to 100000, so the stripper doesn't split it into multiple cells.
<table>
<tr>
<td>
<a href="https://github.com/user-attachments/assets/0d237993-edea-4ab6-9ac0-e4fe896ba2d3">
  <img width="300" alt="kim10um_frontal_7100_pr" src="https://github.com/user-attachments/assets/0d237993-edea-4ab6-9ac0-e4fe896ba2d3" />
</a>

</td>

</td>
<td>
<a href="https://github.com/user-attachments/assets/4d52f1b5-dc3a-4a3d-ae09-5af8429b321e">
  <img width="300" alt="kim10um_frontal_9100_pr" src="https://github.com/user-attachments/assets/4d52f1b5-dc3a-4a3d-ae09-5af8429b321e" />
</a>

</td>
</tr>
</table>

- New test to test the functionality of the method introduced.

## How has this PR been tested?
- Tests
- New test
- Examples above and /examples\
- Several different position on kim

## Is this a breaking change?
no

## Does this PR require an update to the documentation?
no

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
