### PR TITLE
Fix minor typos in doctrings and examples

### DIFF
--- a/brainglobe_heatmap/heatmaps.py
+++ b/brainglobe_heatmap/heatmaps.py
@@ -75,7 +75,7 @@ def find_annotation_position_inside_polygon(
       splitting self-intersecting areas into separate valid polygons.
       When this happens, the function gets the largest polygon by area.
     - Uses Shapely's polylabel algorithm with a tolerance of 0.1
-      that accepts a polygon after edge cases resolved.
+      that accepts a polygon after edge cases are resolved.
     """
     if polygon_vertices.shape[0] < 4:
         return None

--- a/brainglobe_heatmap/planner.py
+++ b/brainglobe_heatmap/planner.py
@@ -77,7 +77,7 @@ class plan(Heatmap):
 
     def show(self):
         """
-        Renders the hetamap visualization as a 3D scene in brainrender.
+        Renders the heatmap visualization as a 3D scene in brainrender.
         """
         self.scene.root._mesh.alpha(0.3)
 

--- a/brainglobe_heatmap/slicer.py
+++ b/brainglobe_heatmap/slicer.py
@@ -56,7 +56,7 @@ class Slicer:
         if isinstance(orientation, str):
             axidx = get_ax_idx(orientation)
 
-            # get the two points the plances are centered at
+            # get the two points the planes are centered at
             shift = np.zeros(3)
             shift[axidx] -= thickness
             p1 = _position - shift
@@ -133,7 +133,7 @@ class Slicer:
 
     def slice_scene(self, scene: Scene, regions: List[Actor]):
         """
-        Slices the meshes in a 3D brainrender scene using the gien planes
+        Slices the meshes in a 3D brainrender scene using the given planes
         """
         # slice the scene
         for _, plane in enumerate((self.plane0, self.plane1)):

--- a/examples/heatmap_2d.py
+++ b/examples/heatmap_2d.py
@@ -1,5 +1,5 @@
 """
-This example shows how to use visualize a heatmap in 2D
+This example shows how to visualize a heatmap in 2D
 """
 
 import brainglobe_heatmap as bgh

--- a/examples/heatmap_3d.py
+++ b/examples/heatmap_3d.py
@@ -1,5 +1,5 @@
 """
-This example shows how to use visualize a heatmap in 3D
+This example shows how to visualize a heatmap in 3D
 """
 
 import brainglobe_heatmap as bgh


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [✔️] Other

**Why is this PR needed?**
This PR fixes minor typos and small grammar issues in docstrings and examples/files to improve clarity.

**What does this PR do?**
1. Corrects spelling errors:
- hetamap -> heatmap
- plances -> planes
- gien -> given

2. Small grammar issues in examples/files docstrings

## References
None

## How has this PR been tested?
Only documentation changes, no functional modifications

## Is this a breaking change?
No

## Does this PR require an update to the documentation?
No, this PR corrects typos only in existing text.

## Checklist:

- [✔️] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [✔️] The code has been formatted with [pre-commit](https://pre-commit.com/)
