### PR TITLE
Pin `brainrender` to 2.1.19 to avoid h5py version mismatch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dynamic = ["version"]
 
-dependencies = ["brainrender>=2.1.17", "matplotlib", "numpy", "myterial", "rich", "shapely"]
+dependencies = ["brainrender>=2.1.19", "matplotlib", "numpy", "myterial", "rich", "shapely"]
 
 license = { text = "MIT" }
 


### PR DESCRIPTION
See https://github.com/openbraininstitute/MorphIO/issues/35

Once resolved we can unpin.