### PR TITLE
Add unit tests for check_values() and get_ax_idx()

### DIFF
--- a/tests/test_unit/test_check_values.py
+++ b/tests/test_unit/test_check_values.py
@@ -17,37 +17,37 @@ def mock_atlas():
 
 # Tests for valid inputs in function check_values in heatmaps.py
 class TestValidInput:
-    def test_singleRegion(self, mock_atlas):
+    def test_single_region(self, mock_atlas):
         values = {"TH": 0.9}
         vmax, vmin = check_values(values, mock_atlas)
         assert vmax == 0.9
         assert vmin == 0.9
 
-    def test_multipleRegions(self, mock_atlas):
+    def test_multiple_regions(self, mock_atlas):
         values = {"TH": 0.9, "RSP": 1, "AI": 0.5, "SS": 0.3}
         vmax, vmin = check_values(values, mock_atlas)
         assert vmax == 1
         assert vmin == 0.3
 
-    def test_integetInput(self, mock_atlas):
+    def test_integer_input(self, mock_atlas):
         values = {"TH": 1, "RSP": 0, "AI": -1}
         vmax, vmin = check_values(values, mock_atlas)
         assert vmax == 1
         assert vmin == -1
 
-    def test_int_and_floatInput(self, mock_atlas):
+    def test_int_and_float_input(self, mock_atlas):
         values = {"TH": 1, "RSP": 0.5, "AI": 1}
         vmax, vmin = check_values(values, mock_atlas)
         assert vmax == 1
         assert vmin == 0.5
 
-    def test_sameValues(self, mock_atlas):
+    def test_same_values(self, mock_atlas):
         values = {"TH": 0.5, "RSP": 0.5, "AI": 0.5}
         vmax, vmin = check_values(values, mock_atlas)
         assert vmax == 0.5
         assert vmin == 0.5
 
-    def test_zeroValues(self, mock_atlas):
+    def test_zero_values(self, mock_atlas):
         values = {"TH": 0, "RSP": 0.0, "AI": 0}
         vmax, vmin = check_values(values, mock_atlas)
         assert vmax == 0
@@ -56,19 +56,19 @@ class TestValidInput:
 
 # Tests for NaN(Not a Number) in function check_values in heatmaps.py
 class Test_NaN:
-    def test_allNaN(self, mock_atlas):
+    def test_all_nan(self, mock_atlas):
         values = {"TH": np.nan, "RSP": np.nan}
         vmax, vmin = check_values(values, mock_atlas)
         assert np.isnan(vmax)
         assert np.isnan(vmin)
 
-    def test_someNaN(self, mock_atlas):
+    def test_some_nan(self, mock_atlas):
         values = {"TH": np.nan, "RSP": 0.9, "AI": np.nan}
         vmax, vmin = check_values(values, mock_atlas)
         assert vmax == 0.9
         assert vmin == 0.9
 
-    def test_single_Nan(self, mock_atlas):
+    def test_single_nan(self, mock_atlas):
         values = {"TH": 0.6, "RSP": 0.0, "AI": np.nan}
         vmax, vmin = check_values(values, mock_atlas)
         assert vmax == 0.6
@@ -77,39 +77,33 @@ class Test_NaN:
 
 # Tests for Invalid input in function check_values in heatmaps.py
 class Test_InvalidInput:
-    def test_emptyInput_raises(self, mock_atlas):
+    def test_empty_input(self, mock_atlas):
         values = {}
         vmax, vmin = check_values(values, mock_atlas)
         assert np.isnan(vmax)
         assert np.isnan(vmin)
 
-    def test_NoneInput_raises(self, mock_atlas):
+    def test_none_input_raises(self, mock_atlas):
         values = {"RSP": None}
-        with pytest.raises(
-            ValueError, match="Heatmap values should be floats"
-        ):
+        with pytest.raises(ValueError, match="Heatmap values should be floats"):
             check_values(values, mock_atlas)
 
-    def test_stringInput_raises(self, mock_atlas):
+    def test_string_input_raises(self, mock_atlas):
         values = {"TH": "one"}
-        with pytest.raises(
-            ValueError, match="Heatmap values should be floats"
-        ):
+        with pytest.raises(ValueError, match="Heatmap values should be floats"):
             check_values(values, mock_atlas)
 
-    def test_ListInput_raises(self, mock_atlas):
+    def test_list_input_raises(self, mock_atlas):
         values = {"TH": [0, 1, 0.9]}
-        with pytest.raises(
-            ValueError, match="Heatmap values should be floats"
-        ):
+        with pytest.raises(ValueError, match="Heatmap values should be floats"):
             check_values(values, mock_atlas)
 
-    def test_UnknownRegion_raises(self, mock_atlas):
+    def test_unknown_region_raises(self, mock_atlas):
         values = {"FAKE_REGION": 1}
         with pytest.raises(ValueError, match="not recognized"):
             check_values(values, mock_atlas)
 
-    def test_UnknownRegion_with_validRegion_raises(self, mock_atlas):
+    def test_unknown_region_with_valid_region_raises(self, mock_atlas):
         values = {"TH": 1, "UNKNOWN": 1}
         with pytest.raises(ValueError, match="not recognized"):
             check_values(values, mock_atlas)

--- a/tests/test_unit/test_check_values.py
+++ b/tests/test_unit/test_check_values.py
@@ -85,17 +85,23 @@ class Test_InvalidInput:
 
     def test_none_input_raises(self, mock_atlas):
         values = {"RSP": None}
-        with pytest.raises(ValueError, match="Heatmap values should be floats"):
+        with pytest.raises(
+            ValueError, match="Heatmap values should be floats"
+        ):
             check_values(values, mock_atlas)
 
     def test_string_input_raises(self, mock_atlas):
         values = {"TH": "one"}
-        with pytest.raises(ValueError, match="Heatmap values should be floats"):
+        with pytest.raises(
+            ValueError, match="Heatmap values should be floats"
+        ):
             check_values(values, mock_atlas)
 
     def test_list_input_raises(self, mock_atlas):
         values = {"TH": [0, 1, 0.9]}
-        with pytest.raises(ValueError, match="Heatmap values should be floats"):
+        with pytest.raises(
+            ValueError, match="Heatmap values should be floats"
+        ):
             check_values(values, mock_atlas)
 
     def test_unknown_region_raises(self, mock_atlas):

--- a/tests/test_unit/test_check_values.py
+++ b/tests/test_unit/test_check_values.py
@@ -1,102 +1,115 @@
-import pytest
-import pandas as pd
 import numpy as np
+import pandas as pd
+import pytest
+
 from brainglobe_heatmap.heatmaps import check_values
 
-#Mocking an atlas for the tests
+
+# Mocking an atlas for the tests
 @pytest.fixture
 def mock_atlas():
-    atlas= type("MockAtlas", (), {})()
-    atlas.lookup_df=pd.DataFrame({"acronym": ["TH", "RSP", "AI", "SS", "MO", "VIS", "HIP", "CB"]})
+    atlas = type("MockAtlas", (), {})()
+    atlas.lookup_df = pd.DataFrame(
+        {"acronym": ["TH", "RSP", "AI", "SS", "MO", "VIS", "HIP", "CB"]}
+    )
     return atlas
 
-#Tests for valid inputs in function check_values in heatmaps.py 
+
+# Tests for valid inputs in function check_values in heatmaps.py
 class TestValidInput:
     def test_singleRegion(self, mock_atlas):
-        values={"TH": 0.9}
-        vmax, vmin= check_values(values, mock_atlas)
+        values = {"TH": 0.9}
+        vmax, vmin = check_values(values, mock_atlas)
         assert vmax == 0.9
         assert vmin == 0.9
 
     def test_multipleRegions(self, mock_atlas):
-        values= {"TH":0.9, "RSP":1, "AI":0.5, "SS":0.3}
-        vmax, vmin=check_values(values, mock_atlas)
+        values = {"TH": 0.9, "RSP": 1, "AI": 0.5, "SS": 0.3}
+        vmax, vmin = check_values(values, mock_atlas)
         assert vmax == 1
         assert vmin == 0.3
-    
+
     def test_integetInput(self, mock_atlas):
-        values={"TH": 1, "RSP": 0, "AI": -1}
-        vmax, vmin=check_values(values, mock_atlas)
+        values = {"TH": 1, "RSP": 0, "AI": -1}
+        vmax, vmin = check_values(values, mock_atlas)
         assert vmax == 1
         assert vmin == -1
 
     def test_int_and_floatInput(self, mock_atlas):
-        values={"TH": 1, "RSP": 0.5, "AI": 1}
-        vmax, vmin=check_values(values, mock_atlas)
+        values = {"TH": 1, "RSP": 0.5, "AI": 1}
+        vmax, vmin = check_values(values, mock_atlas)
         assert vmax == 1
         assert vmin == 0.5
 
     def test_sameValues(self, mock_atlas):
-        values={"TH": 0.5, "RSP": 0.5, "AI": 0.5}
-        vmax, vmin=check_values(values, mock_atlas)
+        values = {"TH": 0.5, "RSP": 0.5, "AI": 0.5}
+        vmax, vmin = check_values(values, mock_atlas)
         assert vmax == 0.5
         assert vmin == 0.5
 
     def test_zeroValues(self, mock_atlas):
-        values={"TH": 0, "RSP": 0.0, "AI": 0}
-        vmax, vmin=check_values(values, mock_atlas)
+        values = {"TH": 0, "RSP": 0.0, "AI": 0}
+        vmax, vmin = check_values(values, mock_atlas)
         assert vmax == 0
         assert vmin == 0
 
-#Tests for NaN(Not a Number) in function check_values in heatmaps.py
+
+# Tests for NaN(Not a Number) in function check_values in heatmaps.py
 class Test_NaN:
     def test_allNaN(self, mock_atlas):
-        values={"TH": np.nan, "RSP": np.nan}
-        vmax, vmin=check_values(values, mock_atlas)
+        values = {"TH": np.nan, "RSP": np.nan}
+        vmax, vmin = check_values(values, mock_atlas)
         assert np.isnan(vmax)
         assert np.isnan(vmin)
 
     def test_someNaN(self, mock_atlas):
-        values={"TH": np.nan, "RSP": 0.9, "AI": np.nan}
-        vmax, vmin=check_values(values, mock_atlas)
-        assert vmax==0.9
-        assert vmin==0.9
+        values = {"TH": np.nan, "RSP": 0.9, "AI": np.nan}
+        vmax, vmin = check_values(values, mock_atlas)
+        assert vmax == 0.9
+        assert vmin == 0.9
 
     def test_single_Nan(self, mock_atlas):
-        values={"TH": 0.6, "RSP": 0.0, "AI": np.nan}
-        vmax, vmin=check_values(values, mock_atlas)
+        values = {"TH": 0.6, "RSP": 0.0, "AI": np.nan}
+        vmax, vmin = check_values(values, mock_atlas)
         assert vmax == 0.6
         assert vmin == 0.0
 
-#Tests for Invalid input in function check_values in heatmaps.py
+
+# Tests for Invalid input in function check_values in heatmaps.py
 class Test_InvalidInput:
     def test_emptyInput_raises(self, mock_atlas):
-        values={}
-        vmax, vmin=check_values(values, mock_atlas)
+        values = {}
+        vmax, vmin = check_values(values, mock_atlas)
         assert np.isnan(vmax)
         assert np.isnan(vmin)
 
     def test_NoneInput_raises(self, mock_atlas):
-        values={"RSP": None}
-        with pytest.raises(ValueError, match="Heatmap values should be floats"):
+        values = {"RSP": None}
+        with pytest.raises(
+            ValueError, match="Heatmap values should be floats"
+        ):
             check_values(values, mock_atlas)
 
     def test_stringInput_raises(self, mock_atlas):
-        values={"TH": "one"}
-        with pytest.raises(ValueError, match="Heatmap values should be floats"):
+        values = {"TH": "one"}
+        with pytest.raises(
+            ValueError, match="Heatmap values should be floats"
+        ):
             check_values(values, mock_atlas)
-        
+
     def test_ListInput_raises(self, mock_atlas):
-        values={"TH": [0, 1, 0.9]}
-        with pytest.raises(ValueError, match="Heatmap values should be floats"):
+        values = {"TH": [0, 1, 0.9]}
+        with pytest.raises(
+            ValueError, match="Heatmap values should be floats"
+        ):
             check_values(values, mock_atlas)
 
     def test_UnknownRegion_raises(self, mock_atlas):
-        values={"FAKE_REGION": 1}
+        values = {"FAKE_REGION": 1}
         with pytest.raises(ValueError, match="not recognized"):
             check_values(values, mock_atlas)
 
     def test_UnknownRegion_with_validRegion_raises(self, mock_atlas):
-        values={"TH": 1, "UNKNOWN": 1}
+        values = {"TH": 1, "UNKNOWN": 1}
         with pytest.raises(ValueError, match="not recognized"):
             check_values(values, mock_atlas)

--- a/tests/test_unit/test_check_values.py
+++ b/tests/test_unit/test_check_values.py
@@ -1,0 +1,102 @@
+import pytest
+import pandas as pd
+import numpy as np
+from brainglobe_heatmap.heatmaps import check_values
+
+#Mocking an atlas for the tests
+@pytest.fixture
+def mock_atlas():
+    atlas= type("MockAtlas", (), {})()
+    atlas.lookup_df=pd.DataFrame({"acronym": ["TH", "RSP", "AI", "SS", "MO", "VIS", "HIP", "CB"]})
+    return atlas
+
+#Tests for valid inputs in function check_values in heatmaps.py 
+class TestValidInput:
+    def test_singleRegion(self, mock_atlas):
+        values={"TH": 0.9}
+        vmax, vmin= check_values(values, mock_atlas)
+        assert vmax == 0.9
+        assert vmin == 0.9
+
+    def test_multipleRegions(self, mock_atlas):
+        values= {"TH":0.9, "RSP":1, "AI":0.5, "SS":0.3}
+        vmax, vmin=check_values(values, mock_atlas)
+        assert vmax == 1
+        assert vmin == 0.3
+    
+    def test_integetInput(self, mock_atlas):
+        values={"TH": 1, "RSP": 0, "AI": -1}
+        vmax, vmin=check_values(values, mock_atlas)
+        assert vmax == 1
+        assert vmin == -1
+
+    def test_int_and_floatInput(self, mock_atlas):
+        values={"TH": 1, "RSP": 0.5, "AI": 1}
+        vmax, vmin=check_values(values, mock_atlas)
+        assert vmax == 1
+        assert vmin == 0.5
+
+    def test_sameValues(self, mock_atlas):
+        values={"TH": 0.5, "RSP": 0.5, "AI": 0.5}
+        vmax, vmin=check_values(values, mock_atlas)
+        assert vmax == 0.5
+        assert vmin == 0.5
+
+    def test_zeroValues(self, mock_atlas):
+        values={"TH": 0, "RSP": 0.0, "AI": 0}
+        vmax, vmin=check_values(values, mock_atlas)
+        assert vmax == 0
+        assert vmin == 0
+
+#Tests for NaN(Not a Number) in function check_values in heatmaps.py
+class Test_NaN:
+    def test_allNaN(self, mock_atlas):
+        values={"TH": np.nan, "RSP": np.nan}
+        vmax, vmin=check_values(values, mock_atlas)
+        assert np.isnan(vmax)
+        assert np.isnan(vmin)
+
+    def test_someNaN(self, mock_atlas):
+        values={"TH": np.nan, "RSP": 0.9, "AI": np.nan}
+        vmax, vmin=check_values(values, mock_atlas)
+        assert vmax==0.9
+        assert vmin==0.9
+
+    def test_single_Nan(self, mock_atlas):
+        values={"TH": 0.6, "RSP": 0.0, "AI": np.nan}
+        vmax, vmin=check_values(values, mock_atlas)
+        assert vmax == 0.6
+        assert vmin == 0.0
+
+#Tests for Invalid input in function check_values in heatmaps.py
+class Test_InvalidInput:
+    def test_emptyInput_raises(self, mock_atlas):
+        values={}
+        vmax, vmin=check_values(values, mock_atlas)
+        assert np.isnan(vmax)
+        assert np.isnan(vmin)
+
+    def test_NoneInput_raises(self, mock_atlas):
+        values={"RSP": None}
+        with pytest.raises(ValueError, match="Heatmap values should be floats"):
+            check_values(values, mock_atlas)
+
+    def test_stringInput_raises(self, mock_atlas):
+        values={"TH": "one"}
+        with pytest.raises(ValueError, match="Heatmap values should be floats"):
+            check_values(values, mock_atlas)
+        
+    def test_ListInput_raises(self, mock_atlas):
+        values={"TH": [0, 1, 0.9]}
+        with pytest.raises(ValueError, match="Heatmap values should be floats"):
+            check_values(values, mock_atlas)
+
+    def test_UnknownRegion_raises(self, mock_atlas):
+        values={"FAKE_REGION": 1}
+        with pytest.raises(ValueError, match="not recognized"):
+            check_values(values, mock_atlas)
+
+    def test_UnknownRegion_with_validRegion_raises(self, mock_atlas):
+        values={"TH": 1, "UNKNOWN": 1}
+        with pytest.raises(ValueError, match="not recognized"):
+            check_values(values, mock_atlas)

--- a/tests/test_unit/test_get_ax_idx.py
+++ b/tests/test_unit/test_get_ax_idx.py
@@ -5,6 +5,7 @@ from brainglobe_heatmap.slicer import get_ax_idx
 # Tests for Orientation values in function get_ax_idx in slicer.py
 # Tests for Orientation values in function get_ax_idx in slicer.py
 
+
 @pytest.mark.parametrize(
     "input_str, out_idx",
     [
@@ -16,13 +17,16 @@ from brainglobe_heatmap.slicer import get_ax_idx
 def test_get_ax_idx(input_str, out_idx):
     assert get_ax_idx(input_str) == out_idx
 
+
 def test_invalid_orientation_raises():
     with pytest.raises(ValueError, match="not recognized"):
         get_ax_idx("vertical")
 
+
 def test_case_sensitive_raises():
     with pytest.raises(ValueError, match="not recognized"):
         get_ax_idx("Frontal")
+
 
 def test_empty_value_raises():
     with pytest.raises(ValueError, match="not recognized"):

--- a/tests/test_unit/test_get_ax_idx.py
+++ b/tests/test_unit/test_get_ax_idx.py
@@ -3,9 +3,6 @@ import pytest
 from brainglobe_heatmap.slicer import get_ax_idx
 
 # Tests for Orientation values in function get_ax_idx in slicer.py
-# Tests for Orientation values in function get_ax_idx in slicer.py
-
-
 @pytest.mark.parametrize(
     "input_str, out_idx",
     [

--- a/tests/test_unit/test_get_ax_idx.py
+++ b/tests/test_unit/test_get_ax_idx.py
@@ -2,6 +2,7 @@ import pytest
 
 from brainglobe_heatmap.slicer import get_ax_idx
 
+
 # Tests for Orientation values in function get_ax_idx in slicer.py
 @pytest.mark.parametrize(
     "input_str, out_idx",

--- a/tests/test_unit/test_get_ax_idx.py
+++ b/tests/test_unit/test_get_ax_idx.py
@@ -1,0 +1,25 @@
+import pytest
+from brainglobe_heatmap.slicer import get_ax_idx
+
+#Tests for Orientation values in function get_ax_idx in slicer.py 
+class Test_GetAxIndex:
+    def test_frontal(self):
+        assert get_ax_idx("frontal")==0
+
+    def test_sagittal(self):
+        assert get_ax_idx("sagittal")==2
+
+    def test_horizontal(self):
+        assert get_ax_idx("horizontal")==1
+
+    def test_invalidOrientation(self):
+        with pytest.raises(ValueError, match="not recognized"):
+            get_ax_idx("vertical")
+
+    def test_CaseSensitive_raises(self):
+        with pytest.raises(ValueError, match="not recognized"):
+            get_ax_idx("Frontal")
+
+    def test_emptyValue_raises(self):
+        with pytest.raises(ValueError, match="not recognized"):
+            get_ax_idx("")

--- a/tests/test_unit/test_get_ax_idx.py
+++ b/tests/test_unit/test_get_ax_idx.py
@@ -2,26 +2,28 @@ import pytest
 
 from brainglobe_heatmap.slicer import get_ax_idx
 
-
 # Tests for Orientation values in function get_ax_idx in slicer.py
-class Test_GetAxIndex:
-    def test_frontal(self):
-        assert get_ax_idx("frontal") == 0
+# Tests for Orientation values in function get_ax_idx in slicer.py
 
-    def test_sagittal(self):
-        assert get_ax_idx("sagittal") == 2
+@pytest.mark.parametrize(
+    "input_str, out_idx",
+    [
+        ("frontal", 0),
+        ("horizontal", 1),
+        ("sagittal", 2),
+    ],
+)
+def test_get_ax_idx(input_str, out_idx):
+    assert get_ax_idx(input_str) == out_idx
 
-    def test_horizontal(self):
-        assert get_ax_idx("horizontal") == 1
+def test_invalid_orientation_raises():
+    with pytest.raises(ValueError, match="not recognized"):
+        get_ax_idx("vertical")
 
-    def test_invalidOrientation(self):
-        with pytest.raises(ValueError, match="not recognized"):
-            get_ax_idx("vertical")
+def test_case_sensitive_raises():
+    with pytest.raises(ValueError, match="not recognized"):
+        get_ax_idx("Frontal")
 
-    def test_CaseSensitive_raises(self):
-        with pytest.raises(ValueError, match="not recognized"):
-            get_ax_idx("Frontal")
-
-    def test_emptyValue_raises(self):
-        with pytest.raises(ValueError, match="not recognized"):
-            get_ax_idx("")
+def test_empty_value_raises():
+    with pytest.raises(ValueError, match="not recognized"):
+        get_ax_idx("")

--- a/tests/test_unit/test_get_ax_idx.py
+++ b/tests/test_unit/test_get_ax_idx.py
@@ -1,16 +1,18 @@
 import pytest
+
 from brainglobe_heatmap.slicer import get_ax_idx
 
-#Tests for Orientation values in function get_ax_idx in slicer.py 
+
+# Tests for Orientation values in function get_ax_idx in slicer.py
 class Test_GetAxIndex:
     def test_frontal(self):
-        assert get_ax_idx("frontal")==0
+        assert get_ax_idx("frontal") == 0
 
     def test_sagittal(self):
-        assert get_ax_idx("sagittal")==2
+        assert get_ax_idx("sagittal") == 2
 
     def test_horizontal(self):
-        assert get_ax_idx("horizontal")==1
+        assert get_ax_idx("horizontal") == 1
 
     def test_invalidOrientation(self):
         with pytest.raises(ValueError, match="not recognized"):


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
This PR increases the test coverage for functions that currently don't have any dedicated tests: `check_values()` in `heatmaps.py` and `get_ax_idx()` in `slicer.py`.

**What does this PR do?**
Adds total of 21 new tests in two new test files: 
- `test_check_values.py` — 15 tests covering valid inputs (single/multiple regions, integers, floats, zeros), NaN handling (all NaN, partial NaN), and invalid inputs (None, strings, lists, unknown regions)
- `test_get_ax_idx.py` — 6 tests covering valid orientations (frontal, sagittal, horizontal), case sensitivity, and invalid/empty values
Also uses a mock atlas fixture so no atlas download or network access needed.

## References
Relates to issue #23

## How has this PR been tested?
All 21 tests pass locally with `pytest tests/test_unit/ -v` on Python 3.13.5 / Windows.

Please explain how any new code has been tested, and how you have ensured that no existing functionality has changed.

## Is this a breaking change?
No. This PR only adds new test files.

## Does this PR require an update to the documentation?
No

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
