### PR TITLE
Update brainrender pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dynamic = ["version"]
 
-dependencies = ["brainrender>=2.1.19", "matplotlib", "numpy", "myterial", "rich", "shapely"]
+dependencies = ["brainrender>=2.1.20", "matplotlib", "numpy", "myterial", "rich", "shapely"]
 
 license = { text = "MIT" }
 


### PR DESCRIPTION
Following https://github.com/brainglobe/brainrender/releases/tag/v2.1.20, this updates the pin to ensure the correct `morphapi` version is fetched