### PR TITLE
Pins numba version to avoid uv pip install issues in CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dev = [
     "pytest",
     "pytest-cov",
     "coverage",
+    "numba >= 0.61.0", # Fix for uv pip install
     "tox",
     "black",
     "mypy",


### PR DESCRIPTION
Pining `numba >= 0.6.1` to avoid errors in dependency resolution using `uv pip`.

See https://brainglobe.zulipchat.com/#narrow/channel/408841-development/topic/.60brainglobe-heatmap.60.20test.20failure/with/608720217 for discussion