### PR TITLE
`brainglobe-atlasapi` V3 compatibility

### DIFF
--- a/examples/cellfinder_cell_density.py
+++ b/examples/cellfinder_cell_density.py
@@ -8,7 +8,6 @@ from pathlib import Path
 
 import pandas as pd
 from brainglobe_atlasapi.bg_atlas import BrainGlobeAtlas
-from brainrender._io import load_mesh_from_file
 
 import brainglobe_heatmap as bgh
 
@@ -46,10 +45,14 @@ cells_summary.set_index("parent_region", inplace=True)
 
 # Get regions' volume
 volumes = []
+vox_size = (
+    atlas.resolution[0] * atlas.resolution[1] * atlas.resolution[2]
+) / 1e9  # convert to mm^3
+
 for region in cells_summary.index:
-    obj_file = str(atlas.meshfile_from_structure(region))
-    mesh = load_mesh_from_file(obj_file)
-    volumes.append(mesh.volume())
+    mask = atlas.get_structure_mask(region)
+    volume = mask.sum() * vox_size
+    volumes.append(volume)
 
 # Calculate the density using atlas volume for each region
 cells_summary["volume_mm3"] = volumes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dynamic = ["version"]
 
-dependencies = ["brainrender>=2.1.20", "matplotlib", "numpy", "myterial", "rich", "shapely"]
+dependencies = ["brainrender>=2.2.0", "matplotlib", "numpy", "myterial", "rich", "shapely"]
 
 license = { text = "MIT" }
 


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
The test suite was failing when ran with `brainglobe-atlasapi==3.0.0rc1`.

**What does this PR do?**
Pins `brainrender` to the latest version (which has fixes required for V3 compatibility. Alters the `cellfinder_cell_density.py` example to not load the meshes directly, but use the masks to calculate the volume of each region.

Corrected the units used. The script claims the results are in cells/mm^2 but the original script provided results as cells/um^2.

## References
#146 

Please reference any existing issues/PRs that relate to this PR.

## How has this PR been tested?
Tested locally to ensure the output of the example script remains the same.

## Checklist:

- [x] The code has been tested locally
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
